### PR TITLE
chore: update konbini to v0.2.5

### DIFF
--- a/.ao/ao.yaml
+++ b/.ao/ao.yaml
@@ -18,8 +18,8 @@ autonomy:
 
 # --- Git 戦略 ---
 git:
-  strategy: worktree            # worktree（超推奨） | branch
-  base_branch: main             # ベースブランチ（main, develop, 任意のブランチ）
+  strategy: worktree    # worktree（超推奨） | branch
+  base_branch: main  # ベースブランチ（main, develop, 任意のブランチ）
   lock_base_branch: true        # ベースブランチを直接変更しない（推奨）
   branch_prefix: konbini/
 
@@ -155,6 +155,11 @@ review_comments:
   format: "[ao-{role}]"
   auto_resolve: true
   sync_to_memory: true
+
+# --- CLAUDE.md ---
+claude_md:
+  language: ja
+  path: CLAUDE.md
 
 # --- 学習ループ ---
 memory:

--- a/.claude/commands/kiro/spec-init.md
+++ b/.claude/commands/kiro/spec-init.md
@@ -10,6 +10,8 @@ Initialize a new feature specification directory and generate initial requiremen
 
 ## Instructions
 
+0. **Worktree guard** — Before anything else, check if you are working in a git worktree (not on the main/master branch). If you are on the main branch, **stop and create a worktree first** using the `superpowers:using-git-worktrees` skill or `git worktree add`. Do NOT proceed with spec initialization until you are in an isolated worktree.
+
 1. **Read product context** from `.ao/steering/product.md` if it exists. Use this to understand the product vision, target users, and strategic goals.
 
 2. **Create the spec directory** at `.kiro/specs/$FEATURE_NAME/`.

--- a/bun.lock
+++ b/bun.lock
@@ -30,7 +30,7 @@
         "unified": "^11.0.5",
       },
       "devDependencies": {
-        "@kaze-jp/konbini": "^0.2.4",
+        "@kaze-jp/konbini": "^0.2.5",
         "@tailwindcss/vite": "^4.2.1",
         "@tauri-apps/cli": "^2.10.0",
         "@types/mdast": "^4.0.4",
@@ -191,7 +191,7 @@
 
     "@jridgewell/trace-mapping": ["@jridgewell/trace-mapping@0.3.31", "", { "dependencies": { "@jridgewell/resolve-uri": "3.1.2", "@jridgewell/sourcemap-codec": "1.5.5" } }, "sha512-zzNR+SdQSDJzc8joaeP8QQoCQr8NuYx2dIIytl1QeBEZHJ9uW6hebsrYgbz8hJwUQao3TWCMtmfV8Nu1twOLAw=="],
 
-    "@kaze-jp/konbini": ["@kaze-jp/konbini@0.2.4", "", { "bin": { "konbini": "dist/cli.js" } }, "sha512-SVkdUQJe5JuF/G+EIm21iJlUZC7nPbIWEgWJcrBMBfLCLcNTRJcI7Gr363oINUfDKLEWsCiYHSzkQFqeGzllCg=="],
+    "@kaze-jp/konbini": ["@kaze-jp/konbini@0.2.5", "", { "bin": { "konbini": "dist/cli.js" } }, "sha512-I4cNVKM/ps/A2ocslPZGZdqoQHsG8h8HoyJyCGIv5kdAHNoUx/yB3jmoex5gp/q5jVuQerbw34r40pK1ffH/ig=="],
 
     "@lezer/common": ["@lezer/common@1.5.1", "", {}, "sha512-6YRVG9vBkaY7p1IVxL4s44n5nUnaNnGM2/AckNgYOnxTG2kWh1vR8BMxPseWPjRNpb5VtXnMpeYAEAADoRV1Iw=="],
 

--- a/package.json
+++ b/package.json
@@ -36,7 +36,7 @@
     "unified": "^11.0.5"
   },
   "devDependencies": {
-    "@kaze-jp/konbini": "^0.2.4",
+    "@kaze-jp/konbini": "^0.2.5",
     "@tailwindcss/vite": "^4.2.1",
     "@tauri-apps/cli": "^2.10.0",
     "@types/mdast": "^4.0.4",


### PR DESCRIPTION
## Summary
- konbini を v0.2.4 → v0.2.5 にアップデート
- spec-init に worktree ガードを追加（main ブランチでの直接 spec 作成を防止）
- ao.yaml のプリセットを solo-full-auto に維持

## Test plan
- [ ] `bunx konbini init` が正常に動作すること
- [ ] `/kiro:spec-init` で worktree ガードが機能すること

🤖 Generated with [Claude Code](https://claude.com/claude-code)