### PR TITLE
chore: bump version to 0.3.8

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,12 @@
 
 All notable changes to this project will be documented in this file.
 
+## [0.3.8] - 2026-04-10
+
+### Fixed
+
+- **起動時にローディングで止まる問題**: `onMount` 内の初期化処理でエラーが発生した場合にウィンドウが表示されず、`viewMode` が `"loading"` のまま永遠に止まるバグを修正。`setupTauriListeners()` のエラーハンドリング追加、CLI引数なし時のdemoモードフォールバック、2秒タイムアウトによる強制遷移、`finally` ブロックでのウィンドウ表示保証を実装。
+
 ## [0.3.7] - 2026-03-13
 
 ### Changed
@@ -89,6 +95,7 @@ All notable changes to this project will be documented in this file.
 - IME 入力の vim normal モードでのブロック
 - Homebrew tap 経由のインストール
 
+[0.3.8]: https://github.com/kaze-jp/kusa/releases/tag/v0.3.8
 [0.3.7]: https://github.com/kaze-jp/kusa/releases/tag/v0.3.7
 [0.3.6]: https://github.com/kaze-jp/kusa/releases/tag/v0.3.6
 [0.3.5]: https://github.com/kaze-jp/kusa/releases/tag/v0.3.5

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "kusa",
-  "version": "0.3.7",
+  "version": "0.3.8",
   "type": "module",
   "scripts": {
     "dev": "vite",

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "kusa"
-version = "0.3.7"
+version = "0.3.8"
 description = "AI開発者のためのMarkdownエディター"
 authors = ["kaze-jp"]
 edition = "2021"

--- a/src-tauri/tauri.conf.json
+++ b/src-tauri/tauri.conf.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://raw.githubusercontent.com/tauri-apps/tauri/dev/crates/tauri-config-schema/schema.json",
   "productName": "kusa",
-  "version": "0.3.7",
+  "version": "0.3.8",
   "identifier": "jp.kaze.kusa",
   "build": {
     "frontendDist": "../dist",

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -645,52 +645,80 @@ const App: Component = () => {
   // -----------------------------------------------------------------------
 
   onMount(async () => {
-    // 1. Initialize window mode
-    try {
-      const mode = (await invoke<string>("get_window_mode")) as WindowMode;
-      initWindowMode(mode);
-    } catch (err) {
-      console.error("Failed to get window mode, defaulting to full:", err);
-      initWindowMode("full");
-    }
-    setModeReady(true);
+    // Safety net: if still loading after 2s, force transition to demo mode
+    // and ensure the window is visible
+    const loadingTimeout = setTimeout(() => {
+      if (viewMode() === "loading") {
+        console.warn("[kusa] Loading timeout reached, falling back to demo mode");
+        setViewMode("demo");
+      }
+      getCurrentWindow().show().catch(() => {});
+    }, 2000);
 
-    // 2. Setup Tauri event listeners (for drag-drop, single-instance, etc.)
-    await setupTauriListeners();
-
-    // 3. Pull CLI args from backend (avoids race condition with events)
     try {
-      const args = await invoke<{ file?: string; clipboard?: boolean; dir?: string } | null>("get_cli_args");
-      if (args) {
-        if (args.file) {
-          await openFileInTab(args.file);
-        } else if (args.clipboard) {
-          const result = await resolveInputSource({ clipboard: true });
-          if (result) {
-            initialInputResolved = true;
-            displayBufferContent(result);
-          }
-        } else if (args.dir) {
-          setDirPath(args.dir);
-          try {
-            const files = await invoke<MdFileEntry[]>("list_md_files", { dirPath: args.dir });
-            setFileList(files);
-            if (tabStore.tabCount() === 0) {
+      // 1. Initialize window mode
+      try {
+        const mode = (await invoke<string>("get_window_mode")) as WindowMode;
+        initWindowMode(mode);
+      } catch (err) {
+        console.error("Failed to get window mode, defaulting to full:", err);
+        initWindowMode("full");
+      }
+      setModeReady(true);
+
+      // 2. Setup Tauri event listeners (for drag-drop, single-instance, etc.)
+      try {
+        await setupTauriListeners();
+      } catch (err) {
+        console.error("Failed to setup Tauri listeners:", err);
+      }
+
+      // 3. Pull CLI args from backend (avoids race condition with events)
+      try {
+        const args = await invoke<{ file?: string; clipboard?: boolean; dir?: string } | null>("get_cli_args");
+        if (args) {
+          if (args.file) {
+            await openFileInTab(args.file);
+          } else if (args.clipboard) {
+            const result = await resolveInputSource({ clipboard: true });
+            if (result) {
+              initialInputResolved = true;
+              displayBufferContent(result);
+            }
+          } else if (args.dir) {
+            setDirPath(args.dir);
+            try {
+              const files = await invoke<MdFileEntry[]>("list_md_files", { dirPath: args.dir });
+              setFileList(files);
+              if (tabStore.tabCount() === 0) {
+                setViewMode("file-list");
+              }
+            } catch (err) {
+              console.error("Failed to list md files:", err);
+              setFileList([]);
               setViewMode("file-list");
             }
-          } catch (err) {
-            console.error("Failed to list md files:", err);
-            setFileList([]);
-            setViewMode("file-list");
           }
         }
+      } catch (err) {
+        console.error("Failed to get CLI args:", err);
+      }
+
+      // 4. If no input was resolved and still loading, show demo mode
+      if (viewMode() === "loading") {
+        setViewMode("demo");
       }
     } catch (err) {
-      console.error("Failed to get CLI args:", err);
+      // Catch-all: ensure we never stay stuck on loading
+      console.error("[kusa] Unexpected error during initialization:", err);
+      if (viewMode() === "loading") {
+        setViewMode("demo");
+      }
+    } finally {
+      // Always show the window and clear the timeout
+      clearTimeout(loadingTimeout);
+      getCurrentWindow().show().catch(() => {});
     }
-
-    // 4. Show window once the frontend is ready
-    getCurrentWindow().show();
   });
 
   // Process markdown to HTML


### PR DESCRIPTION
## Summary

- Fix startup hang where the app gets stuck on loading screen indefinitely
- Add error handling for `setupTauriListeners()` 
- Add 2s timeout fallback to demo mode
- Ensure `getCurrentWindow().show()` is always called via `finally` block

## Release 0.3.8