### PR TITLE
chore: update Cargo.lock for 0.3.8

### DIFF
--- a/src-tauri/Cargo.lock
+++ b/src-tauri/Cargo.lock
@@ -2191,7 +2191,7 @@ dependencies = [
 
 [[package]]
 name = "kusa"
-version = "0.3.7"
+version = "0.3.8"
 dependencies = [
  "base64 0.22.1",
  "dirs",


### PR DESCRIPTION
Update Cargo.lock for 0.3.8 build