### PR TITLE
chore: bump version to 0.3.9

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,12 @@
 
 All notable changes to this project will be documented in this file.
 
+## [0.3.9] - 2026-04-10
+
+### Fixed
+
+- **相対パスが解決できない問題**: `open -a` によるrelaunch時にcwdが変わるため、相対パスのファイルが開けなかった。relaunch前に全ての相対パスをcwd基準で絶対パスに変換するように修正。ファイルが存在しない場合でもcwdと結合して絶対パス化する。
+
 ## [0.3.8] - 2026-04-10
 
 ### Fixed
@@ -95,6 +101,7 @@ All notable changes to this project will be documented in this file.
 - IME 入力の vim normal モードでのブロック
 - Homebrew tap 経由のインストール
 
+[0.3.9]: https://github.com/kaze-jp/kusa/releases/tag/v0.3.9
 [0.3.8]: https://github.com/kaze-jp/kusa/releases/tag/v0.3.8
 [0.3.7]: https://github.com/kaze-jp/kusa/releases/tag/v0.3.7
 [0.3.6]: https://github.com/kaze-jp/kusa/releases/tag/v0.3.6

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "kusa",
-  "version": "0.3.8",
+  "version": "0.3.9",
   "type": "module",
   "scripts": {
     "dev": "vite",

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "kusa"
-version = "0.3.8"
+version = "0.3.9"
 description = "AI開発者のためのMarkdownエディター"
 authors = ["kaze-jp"]
 edition = "2021"

--- a/src-tauri/src/main.rs
+++ b/src-tauri/src/main.rs
@@ -48,16 +48,28 @@ fn main() {
                         .cloned()
                         .collect();
 
-                    // Resolve relative file paths to absolute before relaunching
+                    // Resolve relative file paths to absolute before relaunching.
+                    // `open -a` changes cwd, so relative paths must be resolved here.
+                    let cwd = std::env::current_dir().ok();
                     let resolved_args: Vec<String> = user_args
                         .iter()
                         .map(|arg| {
                             if !arg.starts_with('-') {
                                 let p = std::path::Path::new(arg);
-                                if p.exists() {
-                                    if let Ok(abs) = std::fs::canonicalize(p) {
-                                        return abs.to_string_lossy().to_string();
-                                    }
+                                // Already absolute — just canonicalize if possible
+                                if p.is_absolute() {
+                                    return std::fs::canonicalize(p)
+                                        .map(|a| a.to_string_lossy().to_string())
+                                        .unwrap_or_else(|_| arg.clone());
+                                }
+                                // Relative path — resolve against cwd
+                                if let Some(ref cwd) = cwd {
+                                    let abs = cwd.join(p);
+                                    // Use canonicalize if the file exists, otherwise keep the joined path
+                                    return std::fs::canonicalize(&abs)
+                                        .unwrap_or(abs)
+                                        .to_string_lossy()
+                                        .to_string();
                                 }
                             }
                             arg.clone()

--- a/src-tauri/tauri.conf.json
+++ b/src-tauri/tauri.conf.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://raw.githubusercontent.com/tauri-apps/tauri/dev/crates/tauri-config-schema/schema.json",
   "productName": "kusa",
-  "version": "0.3.8",
+  "version": "0.3.9",
   "identifier": "jp.kaze.kusa",
   "build": {
     "frontendDist": "../dist",


### PR DESCRIPTION
Release 0.3.9 — fix relative path resolution on relaunch