### PR TITLE
chore: update Cargo.lock for 0.3.9

### DIFF
--- a/src-tauri/Cargo.lock
+++ b/src-tauri/Cargo.lock
@@ -2191,7 +2191,7 @@ dependencies = [
 
 [[package]]
 name = "kusa"
-version = "0.3.8"
+version = "0.3.9"
 dependencies = [
  "base64 0.22.1",
  "dirs",


### PR DESCRIPTION
Update Cargo.lock for 0.3.9 build