### PR TITLE
fix(window): retry ensureWindowVisible instead of swallowing show() failure

### DIFF
--- a/.kiro/specs/fix-frontend-show-failure/design.md
+++ b/.kiro/specs/fix-frontend-show-failure/design.md
@@ -1,0 +1,175 @@
+# Technical Design: fix-frontend-show-failure
+
+## Document Info
+- Feature: fix-frontend-show-failure
+- Status: Approved
+- Created: 2026-05-27
+- Requirements: ./requirements.md
+- Issue: #71
+
+## Architecture Overview
+
+The fix introduces one small helper module on the SolidJS side and replaces two unsafe call sites in `src/App.tsx`. Backend (`src-tauri/`) is intentionally untouched: per issue #69, the Tauri window is created with `.visible(false)` and the frontend retains exclusive responsibility for making the window visible. The helper centralizes this responsibility, adds retry + observability, and isolates the logic for unit testing.
+
+```
+┌────────────────────────────────────────────────────────────┐
+│ src-tauri (untouched)                                      │
+│   window builder: .visible(false)   ← issue #69 policy     │
+└────────────────────────────────────────────────────────────┘
+                          │ window handle
+                          ▼
+┌────────────────────────────────────────────────────────────┐
+│ src/App.tsx :: onMount()                                   │
+│                                                             │
+│  ┌──────────────────────┐    ┌─────────────────────────┐   │
+│  │ loadingTimeout (2s)  │    │ finally block           │   │
+│  │  ↓                   │    │  ↓                      │   │
+│  │ await ensureWindow…  │    │ await ensureWindow…     │   │
+│  └──────────────────────┘    └─────────────────────────┘   │
+└──────────────┬───────────────────────────┬─────────────────┘
+               │                           │
+               ▼                           ▼
+┌────────────────────────────────────────────────────────────┐
+│ src/utils/window-visibility.ts                             │
+│                                                             │
+│  ensureWindowVisible(retries = 3):                          │
+│    for i in 0..retries:                                     │
+│      try: await show(); if await isVisible(): return        │
+│           else: console.warn                                │
+│      catch: console.error                                   │
+│      await sleep(100 * (i+1))                               │
+│    try: await setFocus(); await center(); await show()      │
+│    catch: console.error("FATAL")                            │
+└────────────────────────────────────────────────────────────┘
+```
+
+## Component Design
+
+### Component: `ensureWindowVisible` helper
+
+- **Purpose**: Provide a defensive, observable, retry-driven path to make the Tauri window visible. Replace empty `.catch(() => {})` patterns with a function that logs every failure and tries a strong fallback.
+- **Location**: `src/utils/window-visibility.ts` (new file). The `src/utils/` directory is new.
+- **Dependencies**: `@tauri-apps/api/window` (only).
+- **Interface**: Default-free named export `ensureWindowVisible(retries?: number): Promise<void>`. The function is exported as a named export so vitest tests can import and mock its dependency.
+
+### Component: `App.tsx` (modified)
+
+- **Purpose**: Replace two unsafe `getCurrentWindow().show().catch(() => {})` invocations with awaited calls to the new helper.
+- **Location**: `src/App.tsx`
+- **Dependencies**: Add an import for `ensureWindowVisible` from `./utils/window-visibility`.
+- **Changes**:
+  - Line ~655 (loadingTimeout callback): change the inner callback from sync to async (`async () => { … await ensureWindowVisible(); }`) so the await is honored. Returning a promise from `setTimeout` is fine; nothing relies on the callback's return value.
+  - Line ~720 (`finally` block): replace `getCurrentWindow().show().catch(() => {})` with `await ensureWindowVisible();`. The enclosing function (`onMount`'s async callback) already supports `await`.
+
+## API Contracts
+
+### `ensureWindowVisible(retries?: number): Promise<void>`
+
+- **Signature**:
+  ```typescript
+  export async function ensureWindowVisible(retries?: number): Promise<void>
+  ```
+- **Input**:
+  - `retries` (optional, default `3`): integer, number of show attempts before falling back. Values `< 1` skip the retry loop and execute only the final fallback.
+- **Output**: Resolved `Promise<void>`. The function never rejects — all errors are caught and logged.
+- **Behavior**:
+  1. Obtain the current window via `getCurrentWindow()`.
+  2. For `i` in `[0, retries)`:
+     a. `try { await win.show(); const visible = await win.isVisible(); if (visible) return; console.warn(\`[kusa] show() succeeded but isVisible=false, attempt ${i + 1}\`); } catch (err) { console.error(\`[kusa] window.show() failed (attempt ${i + 1}/${retries}):\`, err); }`
+     b. `await new Promise(r => setTimeout(r, 100 * (i + 1)));`
+  3. Final fallback (single try/catch block): `await win.setFocus(); await win.center(); await win.show();`
+  4. On any throw within the fallback: `console.error("[kusa] FATAL: cannot show window:", err);` and return.
+- **Errors**: None thrown. All errors are caught and logged.
+- **Example**:
+  ```typescript
+  await ensureWindowVisible();           // uses default retries = 3
+  await ensureWindowVisible(5);          // 5 retries
+  await ensureWindowVisible(0);          // skip retries, go straight to fallback
+  ```
+
+## Data Models
+
+No new data models. The helper relies on the Tauri `Window` object returned by `getCurrentWindow()` which already exposes `show()`, `isVisible()`, `setFocus()`, `center()` in the v2 API.
+
+## State Management
+
+No state. The helper is a stateless side-effecting function. It does not interact with SolidJS signals/stores. The visibility state lives in the OS window manager.
+
+## Error Handling Strategy
+
+| Failure Mode | Detection | Action | User Impact |
+|---|---|---|---|
+| `show()` throws | `try/catch` around `await win.show()` | `console.error` with attempt N/total; back off; retry | None visible; logged for debugging |
+| `show()` resolves but `isVisible()` false | Post-show check | `console.warn` with attempt N; back off; retry | None visible; logged for debugging |
+| Retries exhausted | Loop terminates | Fallback chain `setFocus + center + show` | Often recovers; aggressive last-ditch effort |
+| Fallback also throws | `try/catch` around fallback chain | `console.error("FATAL")`; function returns | Window stays hidden; rest of app continues |
+
+The helper is intentionally non-throwing. Both call sites in `App.tsx` are in code paths that must continue (loading timeout fallback, `finally` cleanup); a thrown error would itself be a regression.
+
+## Testing Strategy
+
+### Unit tests (vitest) — `src/utils/window-visibility.test.ts`
+
+The Tauri import is mocked via `vi.mock("@tauri-apps/api/window", …)` exposing a `mockWindow` whose methods are `vi.fn()`. The same pattern is used elsewhere in the codebase for `@tauri-apps/api` mocking.
+
+Test cases:
+
+1. **Success on first try**: `show()` resolves, `isVisible()` returns `true`. Expect: `show` called once, `isVisible` called once, no `setFocus`/`center` calls, no `console.warn`/`console.error`.
+2. **Success after one retry due to isVisible=false**: `isVisible` returns `false` then `true`. Expect: `show` called twice, one `console.warn` containing `attempt 1`, no `console.error`, fallback not invoked.
+3. **Success after retry due to thrown show()**: `show` throws on first call, succeeds on second; `isVisible` returns `true` on second call. Expect: one `console.error` with `attempt 1/3`, `show` called twice, fallback not invoked.
+4. **Retries exhausted; fallback succeeds**: all 3 retries fail (e.g., `isVisible` always `false`). Expect: 3 `console.warn` calls, then `setFocus` + `center` + `show` called once each, no `FATAL` log.
+5. **Full failure; fallback throws**: retries fail and fallback `setFocus` throws. Expect: one `FATAL` `console.error`, function returns normally (no unhandled rejection).
+6. **`retries = 0`**: loop body never runs; fallback executes directly. Expect: no `warn`/`error` from the retry loop; fallback `setFocus + center + show` called.
+
+Timer-sensitive tests use `vi.useFakeTimers()` and advance manually to verify the backoff schedule. Tests use `await vi.advanceTimersByTimeAsync(...)` to flush awaited timer promises.
+
+### Manual verification
+
+After implementation, smoke-test by running `bun run tauri dev` and observing the window appears in normal conditions. Failure paths are hard to reproduce manually without injecting a broken window state plugin; the unit tests are the primary safety net.
+
+## Security Considerations
+
+No authentication, no I/O. The helper interacts only with the local OS window manager via Tauri's window API. There is no new attack surface.
+
+## Implementation Plan (high-level)
+
+1. Create `src/utils/window-visibility.ts` with the helper.
+2. Create `src/utils/window-visibility.test.ts` with vitest unit tests (TDD: tests written before/alongside the helper).
+3. Modify `src/App.tsx`:
+   - Add import `import { ensureWindowVisible } from "./utils/window-visibility";`
+   - Replace `getCurrentWindow().show().catch(() => {})` at line ~655 with `await ensureWindowVisible();` (mark the `setTimeout` callback as `async`).
+   - Replace `getCurrentWindow().show().catch(() => {})` at line ~720 with `await ensureWindowVisible();`.
+4. Run `bun test` and `bun run tsc --noEmit` (or the project's typecheck script).
+
+## Requirements Traceability
+
+| Req | Design element |
+|---|---|
+| FR-001 (helper exists) | `ensureWindowVisible` function in `src/utils/window-visibility.ts` |
+| FR-002 (getCurrentWindow once) | Step 1 of Behavior: obtain `win` once, reuse |
+| FR-003 (up to `retries` attempts) | For-loop `i in [0, retries)` |
+| FR-004 (await show) | Behavior step 2a |
+| FR-005 (await isVisible after show) | Behavior step 2a |
+| FR-006 (return on visible true) | `if (visible) return;` |
+| FR-007 (continue on visible false) | Loop falls through after `console.warn` |
+| FR-008 (fallback setFocus→center→show) | Behavior step 3 |
+| FR-010 (call site 655) | App.tsx modification, loadingTimeout |
+| FR-011 (call site 720) | App.tsx modification, finally |
+| FR-012 (no throw escapes) | Helper never rethrows |
+| FR-020 (retries<1) | Loop body skipped; fallback runs |
+| FR-021 (idempotent) | Native Tauri `show()` on visible window is no-op |
+| FR-030 (error log) | Console.error in catch with `attempt N/total` |
+| FR-031 (warn log) | Console.warn after isVisible=false |
+| FR-032 (backoff schedule) | `setTimeout(r, 100 * (i+1))` |
+| FR-033 (FATAL on fallback failure) | Fallback try/catch logs FATAL |
+| NFR-001 (backoff math) | Same |
+| NFR-002 (no extra delay first-try success) | Loop exits before sleep |
+| NFR-003 (no extra CPU) | Only awaits + a single setTimeout per retry |
+| NFR-010 (file location) | `src/utils/window-visibility.ts` |
+| NFR-011 (no new deps) | Only imports `getCurrentWindow` |
+| NFR-012 (Promise<void>) | Explicit return type |
+| NFR-020 (vitest coverage) | Test plan above |
+| NFR-021 (log assertions) | Test plan: spy `console.warn`/`console.error` |
+| NFR-022 (fake timers) | Test plan: vi.useFakeTimers + advanceTimersByTimeAsync |
+| NFR-030 (Tauri v2 API only) | Imports only `@tauri-apps/api/window` |
+| NFR-031 (no backend change) | Design touches only frontend |

--- a/.kiro/specs/fix-frontend-show-failure/requirements-init.md
+++ b/.kiro/specs/fix-frontend-show-failure/requirements-init.md
@@ -1,0 +1,48 @@
+# Feature: fix-frontend-show-failure
+
+## Overview
+
+Frontend の `getCurrentWindow().show()` が空 catch で握りつぶされていたのを、retry 付きヘルパー `ensureWindowVisible` に置き換える。show 失敗時にログを残し、最終的に setFocus + center + show で強制表示を試みる。これにより `.visible(false)` で作成された window が永久に hidden のままになる致命的な不具合を解消する。
+
+## Product Context
+
+kusa はターミナル AI 開発者向けの軽量 Markdown エディタ。CLI 起動 (`kusa file.md`)、Finder、ドラッグ&ドロップ、URL scheme など多様な起動経路を持つ。Tauri v2 で window builder は `.visible(false)` で window を作成するため、frontend の `getCurrentWindow().show()` が唯一の visibility 確保手段である。この単一障害点が失敗した場合の安全網がなく、ユーザー体験を直接損なう。
+
+## Initial Requirements
+
+### Functional Requirements
+
+- **FR-001**: The kusa frontend shall provide a helper function `ensureWindowVisible(retries?: number)` that attempts to show the current Tauri window with retries and a final fallback strategy.
+- **FR-002**: When the frontend completes the onMount loading timeout (2000ms) path, the system shall call `ensureWindowVisible()` instead of `getCurrentWindow().show().catch(() => {})`.
+- **FR-003**: When the frontend completes the onMount `finally` block, the system shall call `ensureWindowVisible()` instead of `getCurrentWindow().show().catch(() => {})`.
+- **FR-004**: When `ensureWindowVisible` attempts `window.show()`, the system shall verify visibility via `window.isVisible()` after each call and treat `isVisible=false` as a soft failure that triggers the next retry.
+- **FR-005**: If `window.show()` throws an error during a retry, the system shall log the error via `console.error` with attempt number and total retries.
+- **FR-006**: If `window.show()` succeeds but `isVisible()` returns false, the system shall log a warning via `console.warn` with the attempt number.
+- **FR-007**: Where retries are exhausted (default 3 attempts), the system shall execute a final fallback chain `setFocus()` → `center()` → `show()` to force visibility.
+- **FR-008**: If the final fallback also fails, the system shall log the fatal error via `console.error` and allow the application to continue running.
+
+### Non-Functional Requirements
+
+- **NFR-001**: The retry intervals shall use increasing backoff: 100ms, 200ms, 300ms (i.e. `100 * (i + 1)` where i is the 0-indexed attempt number).
+- **NFR-002**: The helper shall not depend on additional Tauri plugins (no `tauri-plugin-dialog`); it must rely solely on `@tauri-apps/api/window` APIs already in use.
+- **NFR-003**: The helper shall be async and return `Promise<void>`; callers shall `await` it so subsequent shutdown/state code runs after visibility is settled.
+- **NFR-004**: The helper shall live in `src/utils/window-visibility.ts` to keep `App.tsx` focused on orchestration and to enable unit testing in isolation.
+- **NFR-005**: The helper shall be unit tested with vitest, covering: success on first try, success after retry, warning on `isVisible=false`, final fallback execution, full failure path.
+
+### Constraints
+
+- **C-001**: Modifications are limited to `src/App.tsx` and a new helper file (e.g., `src/utils/window-visibility.ts`). Backend (`src-tauri/`) MUST NOT be touched — issue #69 mandates keeping `.visible(false)` as the window creation policy.
+- **C-002**: The implementation depends on the Tauri v2 `getCurrentWindow().isVisible()` API.
+- **C-003**: `git commit --no-verify` is forbidden.
+- **C-004**: All commits must follow Conventional Commits.
+
+### Assumptions
+
+- **A-001**: The current `@tauri-apps/api/window` import (`getCurrentWindow`) provides `show()`, `isVisible()`, `setFocus()`, and `center()` methods in Tauri v2.
+- **A-002**: Vitest is configured in the repo (verified: `"test": "vitest run"`, `vitest ^4.0.18` in package.json).
+- **A-003**: Callers in `App.tsx` are inside an async context where `await ensureWindowVisible()` is acceptable (verified for both call sites in `onMount`).
+
+### Open Questions
+
+- **Q-001**: Should the helper expose retry/backoff parameters for future tuning, or hard-code defaults? — Default: expose `retries` parameter (matches issue suggestion); backoff stays hard-coded as 100ms × (i+1).
+- **Q-002**: Is logging via `console.warn` / `console.error` sufficient in production, or do we need a Tauri-level log surface? — Default: console-only (issue explicitly accepts this).

--- a/.kiro/specs/fix-frontend-show-failure/requirements.md
+++ b/.kiro/specs/fix-frontend-show-failure/requirements.md
@@ -1,0 +1,105 @@
+# Requirements: fix-frontend-show-failure
+
+## Document Info
+- Feature: fix-frontend-show-failure
+- Status: Draft
+- Created: 2026-05-27
+- Issue: #71
+
+## Overview
+
+kusa の起動時、Tauri window builder は `.visible(false)` で window を作成し、frontend の `getCurrentWindow().show()` が唯一の visibility 確保手段となっている。`src/App.tsx:655` および `src/App.tsx:720` ではこの `show()` が空 catch (`.catch(() => {})`) で握りつぶされており、失敗した場合に window が永久に hidden のままになる致命的な問題がある。本機能では retry + フォールバック付きヘルパー `ensureWindowVisible` を導入し、可観測性と復元性を確保する。
+
+## Functional Requirements
+
+### Core Behavior
+
+- **FR-001**: The kusa frontend shall expose a helper function `ensureWindowVisible(retries?: number): Promise<void>` that ensures the current Tauri window becomes visible.
+- **FR-002**: When `ensureWindowVisible` is invoked, the system shall obtain the current window via `getCurrentWindow()` from `@tauri-apps/api/window` once and reuse the reference for the duration of the call.
+- **FR-003**: When `ensureWindowVisible` is invoked, the system shall attempt up to `retries` show cycles (default `retries = 3`).
+- **FR-004**: When a show cycle begins, the system shall call `await window.show()`.
+- **FR-005**: When `window.show()` resolves without error, the system shall call `await window.isVisible()` to confirm visibility.
+- **FR-006**: When `window.isVisible()` returns `true`, the system shall return from `ensureWindowVisible` without further retries.
+- **FR-007**: When `window.isVisible()` returns `false` after a successful `show()` call, the system shall continue to the next retry cycle.
+- **FR-008**: When retries are exhausted without visibility confirmation, the system shall execute the final fallback sequence: `await window.setFocus()`, `await window.center()`, `await window.show()` — in that exact order.
+
+### User Interactions
+
+- **FR-010**: When the onMount loading timeout (2000ms) fires, the system shall call `await ensureWindowVisible()` in place of the previous `getCurrentWindow().show().catch(() => {})` at `src/App.tsx:655`.
+- **FR-011**: When the onMount `finally` block executes, the system shall call `await ensureWindowVisible()` in place of the previous `getCurrentWindow().show().catch(() => {})` at `src/App.tsx:720`.
+- **FR-012**: When `ensureWindowVisible` is awaited in `onMount`, the system shall not let an unhandled rejection escape; the helper shall not throw under any code path.
+
+### Edge Cases
+
+- **FR-020**: When `ensureWindowVisible` is called with `retries < 1`, the system shall skip the retry loop and execute only the final fallback sequence.
+- **FR-021**: While the loading timeout fallback path and the `finally` path both invoke `ensureWindowVisible`, the system shall accept redundant calls — repeated invocations are idempotent (calling `show()` on an already visible window is a no-op).
+
+### Error Handling
+
+- **FR-030**: If `await window.show()` rejects during a retry cycle, the system shall log via `console.error("[kusa] window.show() failed (attempt N/total):", err)` where N is the 1-indexed attempt number.
+- **FR-031**: If `await window.isVisible()` resolves with `false` after a successful `show()`, the system shall log via `console.warn("[kusa] show() succeeded but isVisible=false, attempt N")`.
+- **FR-032**: When the system proceeds from one retry attempt to the next, it shall await `100 * (attempt + 1)` milliseconds before the next cycle (100ms, 200ms, 300ms for 3 retries).
+- **FR-033**: If the final fallback sequence throws at any step, the system shall catch the error and log via `console.error("[kusa] FATAL: cannot show window:", err)` and return normally (no rethrow).
+
+## Non-Functional Requirements
+
+### Performance
+
+- **NFR-001**: The retry backoff shall be increasing by 100ms per attempt: `delay = 100 * (attempt + 1)` where `attempt` is 0-indexed.
+- **NFR-002**: When the window becomes visible on the first attempt, the system shall introduce no extra delay beyond a single `show()` + `isVisible()` round-trip.
+- **NFR-003**: The helper shall add no synchronous CPU work beyond the existing `show()` call path on the success-first-try case.
+
+### Code Quality
+
+- **NFR-010**: The helper shall live at `src/utils/window-visibility.ts` to keep `App.tsx` focused on orchestration and to enable isolated unit testing.
+- **NFR-011**: The helper module shall depend only on `@tauri-apps/api/window` (no new Tauri plugins, no new npm dependencies).
+- **NFR-012**: The helper shall be implemented in TypeScript with explicit return type `Promise<void>`.
+
+### Testability
+
+- **NFR-020**: The helper shall be covered by vitest unit tests that mock `getCurrentWindow()` and exercise: success on first try, success after retry (e.g. `isVisible=false` then `true`), full retry exhaustion → fallback success, and full failure → fatal logging path.
+- **NFR-021**: Tests shall verify that `console.warn` and `console.error` are called with the expected messages for each failure branch.
+- **NFR-022**: Tests shall verify the backoff delays elapse as specified (100ms/200ms/300ms) using vitest fake timers.
+
+### Compatibility
+
+- **NFR-030**: The helper shall rely only on Tauri v2 `Window` APIs already used elsewhere in the app: `show()`, `isVisible()`, `setFocus()`, `center()`.
+- **NFR-031**: The change shall not modify `src-tauri/` — the backend `.visible(false)` window builder policy is intentionally preserved per issue #69.
+
+## Acceptance Criteria
+
+1. `src/App.tsx` no longer contains `getCurrentWindow().show().catch(() => {})` at any location.
+2. `src/utils/window-visibility.ts` exports `ensureWindowVisible` and is imported by `App.tsx`.
+3. Both former call sites use `await ensureWindowVisible()`.
+4. `bun test` (vitest) passes; new tests cover the four scenarios listed in NFR-020.
+5. `bun run tauri build` (or equivalent type-check / build) succeeds with no new TypeScript errors.
+6. Issue #71 is referenced via `Closes #71` in the PR body.
+7. No changes to `src-tauri/` directory.
+
+## Traceability
+
+| requirements-init item | Expanded |
+|---|---|
+| FR-001 (helper signature) | FR-001, FR-002, FR-003 |
+| FR-002 (call site 655) | FR-010 |
+| FR-003 (call site 720) | FR-011 |
+| FR-004 (isVisible verification) | FR-005, FR-006, FR-007 |
+| FR-005 (error logging) | FR-030 |
+| FR-006 (isVisible=false warning) | FR-031 |
+| FR-007 (final fallback) | FR-008, FR-033 |
+| FR-008 (fatal logging) | FR-033 |
+| NFR-001 (backoff) | NFR-001, FR-032 |
+| NFR-002 (no plugin) | NFR-011 |
+| NFR-003 (async signature) | NFR-012, FR-012 |
+| NFR-004 (file location) | NFR-010 |
+| NFR-005 (test coverage) | NFR-020, NFR-021, NFR-022 |
+| C-001 (no backend) | NFR-031 |
+| C-002 (isVisible API) | NFR-030 |
+| C-003 (no --no-verify) | (process rule, enforced at commit) |
+| C-004 (Conventional Commits) | (process rule, enforced at commit) |
+
+## Out of Scope
+
+- Adding a UI-level error dialog (e.g., via `tauri-plugin-dialog`) on fatal show failure — issue #71 explicitly defers this.
+- Refactoring `onMount` beyond replacing the two `show()` call sites.
+- Modifying Tauri window builder defaults in `src-tauri/` (preserved per issue #69).

--- a/.kiro/specs/fix-frontend-show-failure/spec.json
+++ b/.kiro/specs/fix-frontend-show-failure/spec.json
@@ -1,0 +1,22 @@
+{
+  "feature_name": "fix-frontend-show-failure",
+  "created_at": "2026-05-27T00:00:00Z",
+  "updated_at": "2026-05-27T00:00:00Z",
+  "language": "ja",
+  "phase": "tasks",
+  "approvals": {
+    "requirements": {
+      "generated": true,
+      "approved": true
+    },
+    "design": {
+      "generated": true,
+      "approved": true
+    },
+    "tasks": {
+      "generated": true,
+      "approved": true
+    }
+  },
+  "ready_for_implementation": true
+}

--- a/.kiro/specs/fix-frontend-show-failure/tasks.md
+++ b/.kiro/specs/fix-frontend-show-failure/tasks.md
@@ -1,0 +1,124 @@
+# Implementation Tasks: fix-frontend-show-failure
+
+## Document Info
+- Feature: fix-frontend-show-failure
+- Total tasks: 4
+- Parallelizable: 1
+- Created: 2026-05-27
+- Issue: #71
+
+## Task Dependency Graph
+
+```
+T-001 (helper + tests)
+   │
+   ▼
+T-002 (App.tsx integration)
+   │
+   ▼
+T-003 (typecheck + bun test)
+   │
+   ▼
+T-004 (manual smoke test)  (P)
+```
+
+## Parallel Execution Groups
+
+- Group A: T-001 (independent — net-new files)
+- Group B: T-002 (depends on T-001)
+- Group C: T-003 (depends on T-002)
+- Group D: T-004 manual verification — can be deferred and is non-blocking once T-003 passes.
+
+There is effectively no parallelism within this fix because everything funnels through `src/App.tsx`. T-001 is logically self-contained but T-002 needs the helper exported.
+
+## Tasks
+
+### T-001: Implement `ensureWindowVisible` helper with vitest unit tests
+- **Description**:
+  - Create `src/utils/window-visibility.ts` exporting `ensureWindowVisible(retries?: number): Promise<void>` per design.
+  - Create `src/utils/window-visibility.test.ts` with vitest unit tests covering: success-first-try, success-after-isVisible-false, success-after-show-throws, retries-exhausted-then-fallback-success, full-failure-fatal-log, `retries=0` skip path.
+  - Use `vi.mock("@tauri-apps/api/window", …)` to inject a mock window with `vi.fn()` methods (`show`, `isVisible`, `setFocus`, `center`).
+  - Use `vi.useFakeTimers()` + `vi.advanceTimersByTimeAsync(...)` for the backoff delays.
+  - Spy on `console.warn` and `console.error` to assert log messages.
+- **Files**:
+  - `src/utils/window-visibility.ts` (new)
+  - `src/utils/window-visibility.test.ts` (new)
+- **Dependencies**: None
+- **Acceptance Criteria**:
+  - [ ] `bun test src/utils/window-visibility.test.ts` passes with all six cases green.
+  - [ ] Helper has explicit return type `Promise<void>` and never rejects.
+  - [ ] Helper depends only on `@tauri-apps/api/window`.
+  - [ ] Backoff is `100 * (i + 1)` ms (i 0-indexed).
+  - [ ] Fallback executes `setFocus` → `center` → `show` in that order.
+- **Tests**: see Description.
+- **Effort**: Medium
+
+### T-002: Wire `ensureWindowVisible` into App.tsx onMount
+- **Description**:
+  - Add `import { ensureWindowVisible } from "./utils/window-visibility";` near the top of `src/App.tsx`.
+  - Inside the loadingTimeout callback (line ~650), convert the callback to `async` and replace `getCurrentWindow().show().catch(() => {});` with `await ensureWindowVisible();`.
+  - In the `finally` block (line ~720), replace `getCurrentWindow().show().catch(() => {});` with `await ensureWindowVisible();`.
+  - Confirm there are no other `getCurrentWindow().show()` calls in `src/App.tsx`; if found, also route through the helper.
+- **Files**:
+  - `src/App.tsx` (modify)
+- **Dependencies**: T-001
+- **Acceptance Criteria**:
+  - [ ] `grep -n "show().catch" src/App.tsx` returns nothing.
+  - [ ] `grep -n "ensureWindowVisible" src/App.tsx` returns two call sites + one import.
+  - [ ] No other code paths in `src/App.tsx` call `.show()` directly on the window.
+  - [ ] `bun run tsc --noEmit` (or the project's typecheck script) reports no errors.
+- **Tests**: Covered indirectly by manual verification in T-004; the helper has its own unit tests.
+- **Effort**: Small
+
+### T-003: Run automated checks (tests + lint + typecheck)
+- **Description**:
+  - Run `bun test` to execute the full vitest suite.
+  - Run the project's lint / typecheck commands as defined in `package.json` (e.g., `bun run lint`, `bun run typecheck` / `tsc --noEmit`).
+  - Fix any new warnings or failures caused by this change.
+- **Files**: None (verification only).
+- **Dependencies**: T-002
+- **Acceptance Criteria**:
+  - [ ] `bun test` exits 0.
+  - [ ] Typecheck command exits 0.
+  - [ ] No new lint errors.
+- **Tests**: N/A
+- **Effort**: Small
+
+### T-004: Manual smoke test + commit + PR (P)
+- **Description**:
+  - Optional manual run: `bun run tauri dev` to confirm the window still appears on a normal launch.
+  - Commit the changes with Conventional Commits (`fix(window): replace empty catch with ensureWindowVisible helper`).
+  - Push the branch and open a PR whose body contains `Closes #71`.
+- **Files**: git operations only.
+- **Dependencies**: T-003
+- **Acceptance Criteria**:
+  - [ ] Local app launches and window appears (if dev environment available).
+  - [ ] PR is open against `main` with `Closes #71` in body.
+  - [ ] CodeRabbit review is requested.
+- **Tests**: N/A
+- **Effort**: Small
+
+## File Conflict Matrix
+
+| Task | Files | Conflicts With |
+|------|-------|---------------|
+| T-001 | `src/utils/window-visibility.ts`, `src/utils/window-visibility.test.ts` | None |
+| T-002 | `src/App.tsx` | None (T-001 is a different file but T-002 must wait for T-001's export) |
+| T-003 | none | n/a |
+| T-004 | none | n/a |
+
+## Requirements Traceability
+
+| Requirement | Tasks |
+|------------|-------|
+| FR-001 — FR-008 (helper semantics) | T-001 |
+| FR-010, FR-011 (call sites) | T-002 |
+| FR-012 (no throw escapes) | T-001 |
+| FR-020, FR-021 (edge cases) | T-001 |
+| FR-030, FR-031, FR-032, FR-033 (logging + backoff) | T-001 |
+| NFR-001 — NFR-003 (perf) | T-001 |
+| NFR-010 — NFR-012 (location/types/deps) | T-001 |
+| NFR-020 — NFR-022 (testability) | T-001 |
+| NFR-030, NFR-031 (compatibility) | T-001, T-002 |
+| Acceptance #6 (Closes #71) | T-004 |
+| Acceptance #7 (no backend change) | T-001, T-002 |

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -11,7 +11,6 @@ import {
 } from "solid-js";
 import { invoke } from "@tauri-apps/api/core";
 import { listen } from "@tauri-apps/api/event";
-import { getCurrentWindow } from "@tauri-apps/api/window";
 import { getCurrentWebviewWindow } from "@tauri-apps/api/webviewWindow";
 import { save, confirm } from "@tauri-apps/plugin-dialog";
 import { processMarkdown, extractHeadings } from "./lib/markdown";
@@ -30,6 +29,7 @@ import { createEditorLazyLoader, type CMEditorInstance } from "./lib/editor";
 import { createSyncEngine, type SyncEngineInstance } from "./lib/sync";
 import { createScrollSync, type ScrollSyncInstance } from "./lib/scroll-sync";
 import { createBufferSplitStore } from "./lib/bufferSplitStore";
+import { ensureWindowVisible } from "./utils/window-visibility";
 import type { InputContent, CliArgs } from "./lib/types";
 import type { Tab } from "./lib/tabStore";
 import Preview from "./components/Preview";
@@ -647,12 +647,12 @@ const App: Component = () => {
   onMount(async () => {
     // Safety net: if still loading after 2s, force transition to demo mode
     // and ensure the window is visible
-    const loadingTimeout = setTimeout(() => {
+    const loadingTimeout = setTimeout(async () => {
       if (viewMode() === "loading") {
         console.warn("[kusa] Loading timeout reached, falling back to demo mode");
         setViewMode("demo");
       }
-      getCurrentWindow().show().catch(() => {});
+      await ensureWindowVisible();
     }, 2000);
 
     try {
@@ -717,7 +717,7 @@ const App: Component = () => {
     } finally {
       // Always show the window and clear the timeout
       clearTimeout(loadingTimeout);
-      getCurrentWindow().show().catch(() => {});
+      await ensureWindowVisible();
     }
   });
 

--- a/src/utils/window-visibility.test.ts
+++ b/src/utils/window-visibility.test.ts
@@ -1,0 +1,173 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+// Mocks for the Tauri window object methods. They are reset in beforeEach.
+const showMock = vi.fn();
+const isVisibleMock = vi.fn();
+const setFocusMock = vi.fn();
+const centerMock = vi.fn();
+
+vi.mock("@tauri-apps/api/window", () => ({
+  getCurrentWindow: () => ({
+    show: showMock,
+    isVisible: isVisibleMock,
+    setFocus: setFocusMock,
+    center: centerMock,
+  }),
+}));
+
+// Import after vi.mock so the mock is wired up before module evaluation.
+import { ensureWindowVisible } from "./window-visibility";
+
+describe("ensureWindowVisible", () => {
+  let warnSpy: ReturnType<typeof vi.spyOn>;
+  let errorSpy: ReturnType<typeof vi.spyOn>;
+
+  beforeEach(() => {
+    vi.useFakeTimers();
+    showMock.mockReset();
+    isVisibleMock.mockReset();
+    setFocusMock.mockReset();
+    centerMock.mockReset();
+    warnSpy = vi.spyOn(console, "warn").mockImplementation(() => {});
+    errorSpy = vi.spyOn(console, "error").mockImplementation(() => {});
+  });
+
+  afterEach(() => {
+    vi.useRealTimers();
+    warnSpy.mockRestore();
+    errorSpy.mockRestore();
+  });
+
+  it("returns on first try when show succeeds and isVisible=true", async () => {
+    showMock.mockResolvedValue(undefined);
+    isVisibleMock.mockResolvedValue(true);
+
+    await ensureWindowVisible();
+
+    expect(showMock).toHaveBeenCalledTimes(1);
+    expect(isVisibleMock).toHaveBeenCalledTimes(1);
+    expect(setFocusMock).not.toHaveBeenCalled();
+    expect(centerMock).not.toHaveBeenCalled();
+    expect(warnSpy).not.toHaveBeenCalled();
+    expect(errorSpy).not.toHaveBeenCalled();
+  });
+
+  it("retries when isVisible returns false then true, logs warning, no fallback", async () => {
+    showMock.mockResolvedValue(undefined);
+    isVisibleMock.mockResolvedValueOnce(false).mockResolvedValueOnce(true);
+
+    const p = ensureWindowVisible();
+    // Advance 100ms for attempt 1 backoff.
+    await vi.advanceTimersByTimeAsync(100);
+    await p;
+
+    expect(showMock).toHaveBeenCalledTimes(2);
+    expect(isVisibleMock).toHaveBeenCalledTimes(2);
+    expect(setFocusMock).not.toHaveBeenCalled();
+    expect(centerMock).not.toHaveBeenCalled();
+    expect(warnSpy).toHaveBeenCalledTimes(1);
+    expect(warnSpy.mock.calls[0]?.[0]).toContain("attempt 1");
+    expect(errorSpy).not.toHaveBeenCalled();
+  });
+
+  it("retries when show throws, logs error, succeeds on next try", async () => {
+    showMock
+      .mockRejectedValueOnce(new Error("boom"))
+      .mockResolvedValueOnce(undefined);
+    isVisibleMock.mockResolvedValueOnce(true);
+
+    const p = ensureWindowVisible();
+    await vi.advanceTimersByTimeAsync(100);
+    await p;
+
+    expect(showMock).toHaveBeenCalledTimes(2);
+    expect(errorSpy).toHaveBeenCalledTimes(1);
+    expect(errorSpy.mock.calls[0]?.[0]).toContain("attempt 1/3");
+    expect(setFocusMock).not.toHaveBeenCalled();
+    expect(centerMock).not.toHaveBeenCalled();
+  });
+
+  it("exhausts retries and runs fallback setFocus -> center -> show", async () => {
+    showMock.mockResolvedValue(undefined);
+    isVisibleMock.mockResolvedValue(false);
+    setFocusMock.mockResolvedValue(undefined);
+    centerMock.mockResolvedValue(undefined);
+
+    const p = ensureWindowVisible();
+    // 3 retries → backoff 100 + 200 + 300 = 600ms total.
+    await vi.advanceTimersByTimeAsync(600);
+    await p;
+
+    expect(showMock).toHaveBeenCalledTimes(4); // 3 retries + 1 fallback
+    expect(warnSpy).toHaveBeenCalledTimes(3);
+    expect(setFocusMock).toHaveBeenCalledTimes(1);
+    expect(centerMock).toHaveBeenCalledTimes(1);
+    // Fallback order check: setFocus before center before final show.
+    expect(setFocusMock.mock.invocationCallOrder[0]).toBeLessThan(
+      centerMock.mock.invocationCallOrder[0]!,
+    );
+    expect(centerMock.mock.invocationCallOrder[0]).toBeLessThan(
+      showMock.mock.invocationCallOrder[3]!,
+    );
+    // No FATAL: fallback succeeded.
+    const fatalLogged = errorSpy.mock.calls.some((call: unknown[]) =>
+      String(call[0]).includes("FATAL"),
+    );
+    expect(fatalLogged).toBe(false);
+  });
+
+  it("logs FATAL when fallback also throws and returns normally", async () => {
+    showMock.mockResolvedValue(undefined);
+    isVisibleMock.mockResolvedValue(false);
+    setFocusMock.mockRejectedValue(new Error("setFocus failed"));
+
+    const p = ensureWindowVisible();
+    await vi.advanceTimersByTimeAsync(600);
+    await expect(p).resolves.toBeUndefined();
+
+    const fatalLogged = errorSpy.mock.calls.some((call: unknown[]) =>
+      String(call[0]).includes("FATAL"),
+    );
+    expect(fatalLogged).toBe(true);
+  });
+
+  it("with retries=0 skips the loop and runs fallback immediately", async () => {
+    showMock.mockResolvedValue(undefined);
+    setFocusMock.mockResolvedValue(undefined);
+    centerMock.mockResolvedValue(undefined);
+
+    await ensureWindowVisible(0);
+
+    expect(setFocusMock).toHaveBeenCalledTimes(1);
+    expect(centerMock).toHaveBeenCalledTimes(1);
+    expect(showMock).toHaveBeenCalledTimes(1);
+    expect(warnSpy).not.toHaveBeenCalled();
+    expect(errorSpy).not.toHaveBeenCalled();
+  });
+
+  it("uses increasing backoff (100ms, 200ms, 300ms) before each retry", async () => {
+    showMock.mockResolvedValue(undefined);
+    isVisibleMock.mockResolvedValue(false);
+    setFocusMock.mockResolvedValue(undefined);
+    centerMock.mockResolvedValue(undefined);
+
+    const p = ensureWindowVisible();
+
+    // After 0ms: only the first attempt should have run (1 show).
+    await vi.advanceTimersByTimeAsync(0);
+    expect(showMock).toHaveBeenCalledTimes(1);
+
+    // After 100ms: second attempt should have run (2 shows).
+    await vi.advanceTimersByTimeAsync(100);
+    expect(showMock).toHaveBeenCalledTimes(2);
+
+    // After +200ms: third attempt (3 shows).
+    await vi.advanceTimersByTimeAsync(200);
+    expect(showMock).toHaveBeenCalledTimes(3);
+
+    // After +300ms: retries exhausted; fallback runs (4 total shows).
+    await vi.advanceTimersByTimeAsync(300);
+    await p;
+    expect(showMock).toHaveBeenCalledTimes(4);
+  });
+});

--- a/src/utils/window-visibility.ts
+++ b/src/utils/window-visibility.ts
@@ -1,0 +1,53 @@
+import { getCurrentWindow } from "@tauri-apps/api/window";
+
+/**
+ * Ensure the current Tauri window is visible.
+ *
+ * The kusa Tauri window is created with `.visible(false)` (see issue #69),
+ * so the frontend is solely responsible for making the window visible.
+ * Previously this responsibility was a single `getCurrentWindow().show()`
+ * call wrapped in an empty `.catch(() => {})`, which silently swallowed
+ * any failure and left the window permanently hidden.
+ *
+ * This helper:
+ *   1. Tries `show()` up to `retries` times (default 3).
+ *   2. After each attempt, confirms visibility via `isVisible()` and retries
+ *      if `isVisible()` returns `false`.
+ *   3. Backs off by `100 * (i + 1)` ms (100ms, 200ms, 300ms by default).
+ *   4. Logs every failure to the console.
+ *   5. On retry exhaustion, runs a final fallback chain
+ *      `setFocus -> center -> show` to force visibility.
+ *   6. If the fallback also fails, logs a FATAL error and returns normally
+ *      (never throws) so callers do not have to handle exceptions.
+ *
+ * @param retries number of show attempts before falling back (default 3)
+ */
+export async function ensureWindowVisible(retries = 3): Promise<void> {
+  const win = getCurrentWindow();
+
+  for (let i = 0; i < retries; i++) {
+    try {
+      await win.show();
+      const visible = await win.isVisible();
+      if (visible) return;
+      console.warn(
+        `[kusa] show() succeeded but isVisible=false, attempt ${i + 1}`,
+      );
+    } catch (err) {
+      console.error(
+        `[kusa] window.show() failed (attempt ${i + 1}/${retries}):`,
+        err,
+      );
+    }
+    await new Promise((resolve) => setTimeout(resolve, 100 * (i + 1)));
+  }
+
+  // Final fallback: force visibility via setFocus + center + show.
+  try {
+    await win.setFocus();
+    await win.center();
+    await win.show();
+  } catch (err) {
+    console.error("[kusa] FATAL: cannot show window:", err);
+  }
+}


### PR DESCRIPTION
## Summary

Closes #71.

The kusa Tauri window is created with `.visible(false)` (issue #69 policy), so the frontend is solely responsible for making it visible. Previously the two `getCurrentWindow().show()` calls in `onMount` were wrapped in empty `.catch(() => {})`, silently swallowing any failure and leaving the window permanently hidden.

This PR introduces `src/utils/window-visibility.ts` exposing `ensureWindowVisible(retries = 3)` that:

- retries `show()` up to N times with increasing backoff (100ms, 200ms, 300ms);
- verifies visibility via `isVisible()` after each `show()`;
- logs every failure path (`console.warn` for `isVisible=false`, `console.error` for thrown `show()`, FATAL for a failing fallback);
- on retry exhaustion runs `setFocus` -> `center` -> `show` as a last-ditch fallback;
- never throws, so callers in `onMount` can `await` it safely.

Both former call sites in `src/App.tsx` (lines 655 and 720) now use `await ensureWindowVisible()`. The now-unused `getCurrentWindow` import in `App.tsx` was dropped.

Per #69, `src-tauri/` is intentionally untouched.

## Test plan

- [x] `bun run test src/utils/window-visibility.test.ts` — 7/7 pass
- [x] `npx tsc --noEmit` — clean
- [x] `bun run build` — succeeds
- [ ] Manual smoke: `bun run tauri dev` launches and window appears
- [ ] CodeRabbit review

## Tests covered

1. Success on first try
2. Retry when `isVisible=false`, then succeed (warn logged)
3. Retry when `show()` throws, then succeed (error logged)
4. Retries exhausted -> fallback `setFocus + center + show` succeeds
5. Full failure -> FATAL `console.error`, no throw
6. `retries = 0` skips loop and runs fallback directly
7. Backoff schedule is 100/200/300ms via vitest fake timers

Spec: `.kiro/specs/fix-frontend-show-failure/` (requirements / design / tasks).

Generated with [Claude Code](https://claude.com/claude-code).