### PR TITLE
fix: single-instance plugin race condition (issue #70)

### DIFF
--- a/.kiro/specs/fix-single-instance-race/design.md
+++ b/.kiro/specs/fix-single-instance-race/design.md
@@ -1,0 +1,286 @@
+# Technical Design: fix-single-instance-race
+
+## Document Info
+- Feature: fix-single-instance-race
+- Status: Draft
+- Created: 2026-05-27
+- Requirements: ./requirements.md
+- Related: GitHub issue #70; sibling parallel issue #69 (touches same file, disjoint lines)
+
+## Architecture Overview
+
+We introduce a process-global, mutex-protected buffer (`PendingEventBuffer`) and a new Tauri command (`flush_pending_events`) that the frontend invokes once event listeners are wired. The single-instance plugin callback writes to the buffer when the main window does not yet exist, and emits directly otherwise.
+
+```
+                              kusa process (1st instance)
+                              ───────────────────────────────
+2nd instance ──IPC──▶  [single-instance callback]
+                            │
+                            ├─ window exists?  ──yes──▶ resolve_and_emit ─emit─▶ frontend listener
+                            │
+                            └─ no  ──▶ PendingEventBuffer.push((event, payload))
+                                              ▲
+                                              │ drain
+                                              │
+[setup() completes] ─▶ webview created ─▶ frontend mount ─▶ setupTauriListeners()
+                                                                   │
+                                                                   └─▶ invoke("flush_pending_events")
+                                                                              │
+                                                                              └─▶ app.emit(event, payload) × N
+                                                                                          │
+                                                                                          ▼
+                                                                                  frontend listener
+```
+
+## Component Design
+
+### Component: `PendingEventBuffer` (state)
+
+- **Purpose**: Holds `(event_name, payload)` pairs that need to be delivered to the frontend once it is ready.
+- **Location**: `src-tauri/src/lib.rs` (top-level)
+- **Dependencies**: `std::sync::Mutex`
+- **Interface**:
+  ```rust
+  #[derive(Default)]
+  pub struct PendingEventBuffer(pub Mutex<Vec<(String, String)>>);
+  ```
+- **Registered via**: `tauri::Builder::manage(PendingEventBuffer::default())` (placed alongside other `.manage(...)` calls at lines ~160-165, well outside #69's regions).
+
+### Component: `flush_pending_events` (Tauri command)
+
+- **Purpose**: Drain the buffer and re-emit each entry. Invoked once by the frontend after listeners are registered.
+- **Location**: `src-tauri/src/commands.rs`
+- **Dependencies**: `tauri::AppHandle`, `tauri::{Emitter, Manager}`, `crate::PendingEventBuffer`
+- **Interface**:
+  ```rust
+  #[tauri::command]
+  pub fn flush_pending_events(app: tauri::AppHandle);
+  ```
+- **Registered via**: `invoke_handler` block at lines 166-181 (also outside #69's regions). Order in the handler list does not matter functionally; alphabetical/grouped is fine.
+
+#### Testability helper
+
+To keep unit tests independent of `tauri::AppHandle` (which is non-trivial to mock without `tauri::test`), we extract the drain logic into a pure function:
+
+```rust
+pub(crate) fn drain_pending_events<F: FnMut(&str, String)>(
+    buffer: &crate::PendingEventBuffer,
+    mut emit_fn: F,
+) {
+    if let Ok(mut buf) = buffer.0.lock() {
+        for (event, payload) in buf.drain(..) {
+            emit_fn(&event, payload);
+        }
+    }
+    // Poisoned mutex: skip silently (NFR-011 / FR-005)
+}
+```
+
+Then `flush_pending_events` becomes a one-line wrapper:
+
+```rust
+#[tauri::command]
+pub fn flush_pending_events(app: tauri::AppHandle) {
+    use tauri::{Emitter, Manager};
+    let state = app.state::<crate::PendingEventBuffer>();
+    drain_pending_events(&state, |event, payload| {
+        if let Err(e) = app.emit(event, payload) {
+            eprintln!("Failed to emit {} from flush: {}", event, e);
+        }
+    });
+}
+```
+
+This separation lets us unit-test `drain_pending_events` directly (FR-003, FR-004, FR-005, FR-041, FR-042, FR-050) without needing a Tauri runtime.
+
+### Component: single-instance plugin callback (modified)
+
+- **Location**: `src-tauri/src/lib.rs:183-191`
+- **Change**: Branch on `app.get_webview_window("main").is_some()`. On `None`, push to buffer instead of emit. Use `app.try_state::<PendingEventBuffer>()` to avoid panicking if state is somehow not yet registered (defensive).
+- **Pseudocode** (from issue body, lightly hardened):
+  ```rust
+  .plugin(
+      tauri_plugin_single_instance::init(|app, args, _cwd| {
+          if let Some(path) = args.get(1) {
+              if app.get_webview_window("main").is_some() {
+                  resolve_and_emit(app, path);
+              } else if let Some(state) = app.try_state::<PendingEventBuffer>() {
+                  if let Ok(mut buf) = state.0.lock() {
+                      buf.push(("cli-open".to_string(), path.clone()));
+                  }
+              }
+          }
+          if let Some(window) = app.get_webview_window("main") {
+              let _ = window.set_focus();
+          }
+      }),
+  )
+  ```
+
+#### Known limitation — directory args in race window
+
+The buffered branch always uses `"cli-open"` as the event name (per issue body). If a user runs `kusa some-dir/` in the race window (before the main window is created), the frontend will receive `cli-open` and try to open the directory as a file, failing with an error.
+
+**Decision**: Accept this limitation. Rationale:
+1. The issue body and Suggested Fix explicitly prescribe this behaviour.
+2. The race window is ~hundreds of ms; the dominant case is opening files, not directories.
+3. Doing `canonicalize`/`is_dir()` in the callback adds I/O on the IPC thread (small but unbounded latency).
+4. Frontend error handling for "file not found" is already graceful (toast / silent skip).
+
+If needed later, a follow-up can call `resolve_and_emit`'s I/O logic from the callback. Noted as a follow-up below.
+
+### Component: `resolve_and_emit` (modified)
+
+- **Location**: `src-tauri/src/lib.rs:134-149`
+- **Change**: Log emit failures via `eprintln!` instead of silently `let _ =`.
+- **Diff**:
+  ```rust
+  if let Err(e) = emitter.emit("cli-open", canonical.to_string_lossy().to_string()) {
+      eprintln!("Failed to emit cli-open event: {}", e);
+  }
+  ```
+- Apply the same pattern to all three emit sites inside `resolve_and_emit` (raw fallback, dir, file).
+
+### Component: Frontend `setupTauriListeners` (modified)
+
+- **Location**: `src/App.tsx` (function around line 224)
+- **Change**: After all three `listen()` calls resolve and before `onCleanup(...)`, invoke `flush_pending_events`:
+  ```ts
+  await invoke("flush_pending_events").catch(() => {});
+  ```
+- **Order matters** (FR-030): the invoke must come **after** all three listeners are registered, so any buffered events are delivered into live listeners, not dropped.
+
+## API Contracts
+
+### `flush_pending_events`
+
+- **Signature**: `flush_pending_events(app: tauri::AppHandle) -> ()`
+- **Input**: none (besides the implicit `AppHandle` injected by Tauri)
+- **Output**: `()` — fire-and-forget. The frontend does not need to await the emit results.
+- **Errors**:
+  - Mutex poisoned → skip silently (no return value)
+  - `app.emit(...)` returns `Err` → log via `eprintln!`, continue draining (FR-050)
+- **Frontend usage**:
+  ```ts
+  await invoke("flush_pending_events").catch(() => {});
+  ```
+
+### Single-instance callback
+
+- **Signature**: `Fn(&AppHandle, Vec<String>, String)` — unchanged from `tauri_plugin_single_instance` 0.x
+- **Side effects**:
+  - If window exists: emit + focus (current behaviour)
+  - If window absent: push to buffer; focus skipped (no window to focus yet — the cold window will mount and frontend will replay the buffered event)
+
+## Data Models
+
+### `PendingEventBuffer`
+
+- **Fields**:
+  - `0: Mutex<Vec<(String, String)>>` — `(event_name, payload)` queue, FIFO
+- **Validation**: none; both strings are arbitrary
+- **Relationships**: registered as Tauri managed state; reachable from any handler / plugin callback via `app.state::<PendingEventBuffer>()` or `app.try_state::<PendingEventBuffer>()`
+- **Lifetime**: process-global, lives for the lifetime of the `AppHandle`
+
+## State Management
+
+```
+┌────────────────────────────────────────────────────────────────────┐
+│ tauri::Builder                                                     │
+│   .manage(PendingEventBuffer::default())   ← created at startup    │
+│   .plugin(single_instance::init(...))      ← reads/writes buffer   │
+│   .invoke_handler!(flush_pending_events)   ← drains buffer         │
+└────────────────────────────────────────────────────────────────────┘
+
+  single-instance callback ──push──▶ Mutex<Vec<(String, String)>>
+                                                │
+        frontend ─invoke─▶ flush_pending_events ┘ ──emit each──▶ frontend listener
+```
+
+Lock is acquired briefly:
+- `push`: O(1) inside lock
+- `drain`: lock held during drain + emit calls; emit is non-blocking (queues message into webview)
+
+## Error Handling Strategy
+
+| Failure | Strategy | Rationale |
+|---|---|---|
+| Mutex poisoned (single-instance callback) | Skip buffering; no panic | UX: silently fail a single keystroke rather than crash the whole app |
+| Mutex poisoned (flush) | Skip; no panic | Same |
+| `try_state` returns `None` in callback | Skip buffering | Defensive — `manage()` is called before `plugin()`, so this is a "should never happen" but we don't panic |
+| `app.emit(...)` returns `Err` (resolve_and_emit) | `eprintln!` + continue | Diagnostic for issue #70 follow-ups (FR-020) |
+| `app.emit(...)` returns `Err` (flush) | `eprintln!` + continue draining (FR-050) | Don't block remaining buffered entries |
+| Frontend `invoke("flush_pending_events")` rejects | `.catch(() => {})` | listener setup must not fail; flush is best-effort (FR-031) |
+
+## Testing Strategy
+
+### Unit tests (new) — `src-tauri/src/commands.rs#tests`
+
+Test target: `drain_pending_events` (the pure helper exposed as `pub(crate)` from `lib.rs`).
+
+1. **`test_flush_pending_events_empty_buffer_is_noop`** — empty buffer; closure must not be called.
+2. **`test_flush_pending_events_drains_in_fifo_order`** — push 3 entries; verify closure called 3× with correct payloads in order; buffer empty after.
+3. **`test_flush_pending_events_drains_to_empty_on_partial_emit_failure`** — closure simulates partial failure (e.g. always succeeds since signature is `FnMut(&str, String)` with no error path on the helper); we still verify the buffer is fully drained.
+4. **`test_flush_pending_events_poisoned_mutex_is_noop`** — induce poisoning by panicking inside the lock guard from another thread; verify drain function does not panic.
+
+### Integration tests
+Manual smoke test post-build (out of unit-test scope):
+- 1st-instance `kusa README.md` opens correctly.
+- `kusa a.md` + `kusa b.md` within ~100 ms → `b.md` is shown.
+
+### Edge cases to cover
+- FR-040: callback with no `args[1]` — verified by code review (early return).
+- FR-041: multiple buffered entries — covered by test #2 above.
+- FR-042: empty buffer flush — covered by test #1.
+- FR-050: emit failure (best-effort) — `eprintln` path is straightforward; tested via review.
+
+## Security Considerations
+
+- The buffer holds CLI argument strings. These are already trusted (user typed them on their own terminal). No new attack surface.
+- Mutex prevents data races (memory-safety property; not security per se).
+- No new IPC surface beyond the new command (which is a no-args drain).
+
+## Risks & Mitigations
+
+| Risk | Mitigation |
+|---|---|
+| `app.state::<PendingEventBuffer>()` panics if state not managed | Use `try_state` in single-instance callback (defensive); rely on `.manage()` ordering otherwise |
+| Buffer never drained (frontend bug) | Best-effort: stale entries are harmless (no leak, just untriggered listeners). If listener never wires up, the issue is broader than this fix |
+| Sibling #69 merge conflict | #70 touches lines 134-149 + 160-165 (.manage insertion) + 166-181 (invoke_handler addition) + 183-191. #69 touches 119-129 and ~246. Disjoint. |
+| `RunEvent::Opened` path (lines 324-333) has same race | Out of scope for this fix (per issue body). Noted as follow-up. |
+
+## Follow-ups (not in scope)
+
+- **F-1**: Apply same buffer-or-emit pattern to `RunEvent::Opened` handler (currently calls `resolve_and_emit` directly).
+- **F-2**: Use `canonicalize`/`is_dir()` in the single-instance callback so directory args take `cli-open-dir` even in the race window.
+
+## Requirements Traceability
+
+| Requirement | Component / Site |
+|---|---|
+| FR-001 (PendingEventBuffer struct) | `PendingEventBuffer` in lib.rs |
+| FR-002 (`.manage(...)`) | `tauri::Builder` chain in lib.rs |
+| FR-003 (command exposed) | `flush_pending_events` in commands.rs + `invoke_handler` |
+| FR-004 (drain + emit FIFO) | `drain_pending_events` helper |
+| FR-005 (no panic on poisoned mutex) | `if let Ok(...)` guard in `drain_pending_events` |
+| FR-010 (window exists → emit) | single-instance callback `if` branch |
+| FR-011 (window absent → buffer) | single-instance callback `else if` branch |
+| FR-012 (set_focus on window) | single-instance callback (preserved) |
+| FR-013 (no panic on missing state) | `try_state` use |
+| FR-020 (log emit failures) | `resolve_and_emit` updated logging |
+| FR-030 (frontend invoke after listeners) | `setupTauriListeners` (App.tsx) |
+| FR-031 (.catch(() => {})) | `setupTauriListeners` |
+| FR-040 (no args → skip) | `if let Some(path) = args.get(1)` guard (existing) |
+| FR-041 (multi-entry flush) | `drain(..)` + test #2 |
+| FR-042 (empty flush no-op) | `drain` early loop exit + test #1 |
+| FR-050 (continue on emit failure) | `eprintln + continue` in flush closure |
+| NFR-001/002 (perf) | O(1) state setup, brief locks |
+| NFR-010/011 (Mutex + no panic) | `if let Ok(...)` guards |
+| NFR-012 (no duplicate 1st-instance events) | Buffer only written from single-instance callback path (2nd+ instances) |
+| NFR-020/021 (tests) | New unit tests in commands.rs#tests |
+| NFR-030 (warning-free) | Code review + `cargo build --release` |
+| NFR-031 (frontend type-check) | tsc — `invoke` and `.catch(() => {})` are both typed |
+| C-001 (avoid #69 regions) | All edits confined to 134-149, 160-165, 166-181, 183-191 |
+| C-002 (no --no-verify) | Workflow contract |
+| C-003 (preserve resolve_and_emit signature) | Only logging added, signature unchanged |
+| C-004 (no auto-flush) | Backend only flushes on explicit invoke |

--- a/.kiro/specs/fix-single-instance-race/requirements-init.md
+++ b/.kiro/specs/fix-single-instance-race/requirements-init.md
@@ -1,0 +1,57 @@
+# Feature: fix-single-instance-race
+
+## Overview
+
+single-instance plugin の callback が `.setup()` 完了前 (window 作成前) に呼ばれることで発生する race condition を修正する。具体的には、起動直後に 2nd instance を CLI で叩くと `app.get_webview_window("main")` が `None` を返し、`resolve_and_emit` が emit する `cli-open` / `cli-open-dir` イベントが frontend listener 不在のため捨てられる問題に対応する。
+
+修正方針は「pending event を Rust 側で buffer し、frontend listener セットアップ完了後に `flush_pending_events` コマンドを invoke して flush する」というアプローチを採る。
+
+## Product Context
+
+product.md はテンプレートのままで具体的な内容は未記入。本プロジェクト (kusa) のビジョンは CLAUDE.md の通り「ターミナル AI 開発者向けの軽量・高速 Markdown エディター」。**Instant Open** がコアコンセプトであり、CLI から `kusa file.md` で即起動できる体験が壊れる本バグは UX 価値の中核を毀損する。
+
+## Initial Requirements
+
+### Functional Requirements
+
+- **FR-001**: When the user runs `kusa <path>` while a kusa instance is already running, the system shall open / focus to `<path>` in the existing instance.
+- **FR-002**: When the single-instance plugin callback is invoked **before** the main webview window is created, the system shall buffer the `(event_name, payload)` pair in process-local state (`PendingEventBuffer`) instead of emitting it.
+- **FR-003**: When the single-instance plugin callback is invoked **after** the main webview window is created, the system shall emit `cli-open` / `cli-open-dir` via the existing `resolve_and_emit` flow (current behaviour preserved).
+- **FR-004**: After the frontend `setupTauriListeners` finishes registering all Tauri event listeners, the frontend shall invoke a new Tauri command `flush_pending_events`.
+- **FR-005**: When `flush_pending_events` is invoked, the backend shall drain `PendingEventBuffer` and re-emit each buffered `(event_name, payload)` pair via `app.emit(...)`.
+- **FR-006**: While `resolve_and_emit` runs, if the underlying `emit` call returns an `Err`, the system shall log the error via `eprintln!` (so users / CI can diagnose silent failures).
+- **FR-007**: Where the main webview window exists at the time of single-instance callback, the system shall call `window.set_focus()` (current behaviour preserved).
+
+### Non-Functional Requirements
+
+- **NFR-001**: The buffer (`PendingEventBuffer`) shall be protected by a `std::sync::Mutex`; concurrent access from the single-instance callback thread and the IPC handler thread shall not cause data races or undefined behaviour.
+- **NFR-002**: The fix shall not regress the cold-start latency of the 1st instance: no additional work shall be done on the happy path beyond a buffer state registration in `Builder::manage`.
+- **NFR-003**: The fix shall not introduce duplicate `cli-open` / `cli-open-dir` events for the 1st instance (the 1st instance must not receive buffered events that would re-trigger the file already being opened via `get_cli_args`).
+- **NFR-004**: All new and existing Rust unit tests under `src-tauri/` shall pass (`cargo test`).
+- **NFR-005**: The frontend invoke shall use `.catch(() => {})` (or equivalent) so a failure of `flush_pending_events` does not break listener setup.
+
+### Constraints
+
+- **C-001**: `tauri_plugin_single_instance` 0.x の挙動依存 — callback signature `(app: &AppHandle, args: Vec<String>, cwd: String)` を踏襲する。
+- **C-002**: `src-tauri/src/lib.rs` の **lines 119-129** (Full mode window builder) および **line 246 周辺** (`setup()` 内の `create_window` 呼び出し) は touch しない (sibling issue #69 が同じファイルを編集しており、領域を分離してマージ衝突を回避する)。
+- **C-003**: `git commit --no-verify` 禁止 (pre-commit hooks を必ず通す)。
+- **C-004**: `resolve_and_emit` の重複登録は避ける — 既存の関数を再利用し、新たな emit 経路を増やさない。
+- **C-005**: `flush_pending_events` は frontend が必ず呼ぶ責任を負う (backend からの auto-flush は実装しない)。
+
+### Assumptions
+
+- **A-001**: `tauri_plugin_single_instance` の callback が `setup()` 完了前に発火するのは、OS のプロセス間通信が高速に成立した場合に限定される (確率的再現)。
+- **A-002**: `PendingEventBuffer` に積まれるイベントは、frontend が listener をセットアップしてから flush されるまでの間に消費される。長期間バッファに残ることは想定しない。
+- **A-003**: `app.emit(...)` の失敗は通常発生しないが、起動シーケンスの異常時にデバッグ可能であるべきという理由でログを追加する。
+
+### Open Questions
+
+- 現時点で重大な open question はなし。issue 本文に明示された Suggested Fix をベースに進める。
+
+## Acceptance Criteria (Initial)
+
+1. `cargo test` が pass する (既存テスト + 新規 `flush_pending_events` の unit test)。
+2. `cargo build --release` が warning-free で通る。
+3. 既存 1st instance 起動 (`kusa file.md`) で動作が回帰しない。
+4. 2nd instance ケース (`kusa a.md` → 起動直後に `kusa b.md`) で `b.md` が開く。
+5. CodeRabbit レビューで critical / major 指摘なし。

--- a/.kiro/specs/fix-single-instance-race/requirements.md
+++ b/.kiro/specs/fix-single-instance-race/requirements.md
@@ -1,0 +1,117 @@
+# Requirements: fix-single-instance-race
+
+## Document Info
+- Feature: fix-single-instance-race
+- Status: Draft
+- Created: 2026-05-27
+- Related issue: #70
+- Sibling (parallel) work: #69 (modifies disjoint regions of `src-tauri/src/lib.rs`)
+
+## Background
+
+`tauri_plugin_single_instance` の callback は OS 由来の IPC により発火するため、`tauri::Builder::setup()` が完了する前 (= main webview window が生成される前) にも実行されうる。現状の実装はこのケースで:
+1. `resolve_and_emit` がイベントを emit するが、frontend listener が未登録のため event が捨てられる。
+2. `app.get_webview_window("main")` が `None` のため `set_focus()` も発生しない。
+
+結果として、2nd instance のファイル open が反映されず、window も前面化しない。本仕様は本 race condition を pending-event buffer 方式で解消する。
+
+## Functional Requirements
+
+### Core Behavior
+
+- **FR-001**: The system **shall** expose a process-global mutable state struct named `PendingEventBuffer` containing a `Mutex<Vec<(String, String)>>` representing buffered `(event_name, payload)` pairs.
+- **FR-002**: The system **shall** register `PendingEventBuffer::default()` via `tauri::Builder::manage(...)` so it is available through `app.state::<PendingEventBuffer>()`.
+- **FR-003**: The system **shall** expose a new Tauri command `flush_pending_events(app: tauri::AppHandle)` registered in `invoke_handler`.
+- **FR-004**: When `flush_pending_events` is invoked, the system **shall** acquire the `PendingEventBuffer` mutex, drain all entries, and call `app.emit(&event, payload)` for each entry, in FIFO order.
+- **FR-005**: When `flush_pending_events` is invoked and the mutex is poisoned, the system **shall** not panic; it shall fail gracefully (e.g. by returning without emitting).
+
+### single-instance callback path
+
+- **FR-010**: When the single-instance callback is invoked with a non-empty `args[1]` and the main webview window already exists, the system **shall** call `resolve_and_emit(app, args[1])` (current happy-path behaviour preserved).
+- **FR-011**: When the single-instance callback is invoked with a non-empty `args[1]` and the main webview window does **not** yet exist, the system **shall** push `("cli-open", args[1].clone())` to the `PendingEventBuffer`.
+  - Note: We intentionally push the raw CLI argument unresolved (matching the existing `resolve_and_emit` fallback for non-canonicalizable paths). Frontend already handles raw path resolution downstream via existing logic.
+- **FR-012**: When the main webview window exists at the time of single-instance callback invocation, the system **shall** call `window.set_focus()` (current behaviour preserved).
+- **FR-013**: If `app.state::<PendingEventBuffer>()` cannot be obtained or the mutex lock fails inside the single-instance callback, the system **shall** silently skip buffering (best-effort, must not panic).
+
+### resolve_and_emit logging
+
+- **FR-020**: When `resolve_and_emit` calls `emitter.emit("cli-open", ...)` or `emitter.emit("cli-open-dir", ...)` and the result is `Err(e)`, the system **shall** log `Failed to emit <event_name> event: <e>` to stderr via `eprintln!`.
+
+### Frontend integration
+
+- **FR-030**: After the frontend's `setupTauriListeners` (in `src/App.tsx`) finishes registering all Tauri event listeners (cli-open, cli-open-dir, etc.), the frontend **shall** invoke the Tauri command `flush_pending_events`.
+- **FR-031**: If the invoke of `flush_pending_events` rejects, the frontend **shall** suppress the error (`.catch(() => {})`) so listener setup is not interrupted.
+
+### Edge Cases
+
+- **FR-040**: Where the single-instance callback receives no `args[1]` (user ran `kusa` with no path argument), the system **shall not** buffer anything and **shall not** emit `cli-open`/`cli-open-dir`.
+- **FR-041**: Where the buffer contains multiple entries (e.g. user triggered 3 rapid 2nd-instance calls before window readiness), the system **shall** flush all of them on a single `flush_pending_events` invocation.
+- **FR-042**: Where `flush_pending_events` is invoked but the buffer is empty, the system **shall** return without performing any emit calls.
+
+### Error Handling
+
+- **FR-050**: If `emit` inside `flush_pending_events` returns `Err`, the system **shall** continue draining and emitting the remaining buffered entries (one failure must not block others).
+
+## Non-Functional Requirements
+
+### Performance
+
+- **NFR-001**: The system **shall** add no measurable cold-start regression: `PendingEventBuffer::default()` allocation and `.manage(...)` registration are O(1) constant cost.
+- **NFR-002**: The system **shall** hold the `PendingEventBuffer` mutex only for the minimum duration required (push for buffering, drain for flush). No I/O occurs while the lock is held except for the emit calls in flush (which are non-blocking message sends).
+
+### Reliability / Safety
+
+- **NFR-010**: The system **shall** protect the buffer with `std::sync::Mutex` (already required by `Send + Sync` for Tauri managed state).
+- **NFR-011**: The system **shall not** panic on poisoned mutex; both single-instance callback (FR-013) and `flush_pending_events` (FR-005) use `if let Ok(...)` style guards.
+- **NFR-012**: The fix **shall not** introduce duplicate event emission for the 1st instance: the 1st instance receives its initial file path via `get_cli_args` (existing), and the buffer is only populated by the single-instance callback path which only fires for 2nd+ instances.
+
+### Testability
+
+- **NFR-020**: The new command `flush_pending_events` **shall** have a Rust unit test (`#[cfg(test)] mod tests`) verifying:
+  - Empty buffer → no emit, no panic.
+  - Buffer with N entries → buffer is drained to empty after flush.
+  - Function does not panic on poisoned mutex (best-effort).
+- **NFR-021**: All existing tests under `src-tauri/` **shall** continue to pass (`cargo test`).
+
+### Code quality
+
+- **NFR-030**: New Rust code **shall** compile warning-free (`cargo build --release`).
+- **NFR-031**: Frontend changes in `App.tsx` **shall** pass type-check (`tsc --noEmit` or equivalent).
+
+## Constraints
+
+- **C-001**: The implementation **shall not** modify `src-tauri/src/lib.rs` lines 119-129 (Full mode window builder) nor line 246 (`create_window` invocation inside `.setup()`). These regions are owned by sibling issue #69.
+- **C-002**: The implementation **shall not** use `git commit --no-verify`.
+- **C-003**: The implementation **shall** preserve existing `resolve_and_emit` signature and call-sites (no duplicate registrations).
+- **C-004**: Auto-flush from backend (e.g. on `setup()` completion) is **out of scope**; frontend owns the responsibility of calling `flush_pending_events`.
+
+## Acceptance Criteria
+
+1. **2nd-instance race fix**: Running `kusa a.md`, then within ~100 ms running `kusa b.md`, results in `b.md` being shown in the 1st-instance window (manually verified or simulated via test scenario).
+2. **No 1st-instance regression**: Running `kusa file.md` from a clean state opens `file.md` correctly (no duplicate emit, no error log).
+3. **Sibling-issue compatibility**: A 3-way merge with #69 succeeds without conflict in the specified line regions.
+4. **Test pass**: `cargo test` passes including new unit test for `flush_pending_events`.
+5. **Lint/build clean**: `cargo build --release` succeeds warning-free.
+6. **CodeRabbit review**: No critical or major findings.
+
+## Traceability
+
+| requirements-init item | Expanded FR/NFR |
+|---|---|
+| FR-001 (open in existing instance) | FR-010, FR-011, FR-030 (frontend flush) |
+| FR-002 (buffer when window absent) | FR-001, FR-002, FR-011 |
+| FR-003 (preserve emit when window present) | FR-010 |
+| FR-004 (frontend invoke after listeners) | FR-030, FR-031 |
+| FR-005 (drain and emit on flush) | FR-003, FR-004 |
+| FR-006 (log emit failures) | FR-020 |
+| FR-007 (preserve set_focus) | FR-012 |
+| NFR-001 (Mutex protection) | NFR-010, NFR-011 |
+| NFR-002 (no cold-start regression) | NFR-001, NFR-002 |
+| NFR-003 (no duplicate events) | NFR-012 |
+| NFR-004 (tests pass) | NFR-020, NFR-021 |
+| NFR-005 (frontend catch) | FR-031 |
+| C-001..C-005 | C-001..C-004 |
+
+## Open Questions
+
+None at this time. Issue body provides a concrete suggested fix that this requirements document fully captures.

--- a/.kiro/specs/fix-single-instance-race/spec.json
+++ b/.kiro/specs/fix-single-instance-race/spec.json
@@ -1,0 +1,22 @@
+{
+  "feature_name": "fix-single-instance-race",
+  "created_at": "2026-05-27T00:00:00Z",
+  "updated_at": "2026-05-27T00:00:00Z",
+  "language": "ja",
+  "phase": "ready",
+  "approvals": {
+    "requirements": {
+      "generated": true,
+      "approved": true
+    },
+    "design": {
+      "generated": true,
+      "approved": true
+    },
+    "tasks": {
+      "generated": true,
+      "approved": true
+    }
+  },
+  "ready_for_implementation": true
+}

--- a/.kiro/specs/fix-single-instance-race/tasks.md
+++ b/.kiro/specs/fix-single-instance-race/tasks.md
@@ -1,0 +1,198 @@
+# Implementation Tasks: fix-single-instance-race
+
+## Document Info
+- Feature: fix-single-instance-race
+- Total tasks: 7
+- Parallelizable: 1 (T-001 standalone — pure helper)
+- Created: 2026-05-27
+
+## Task Dependency Graph
+
+```
+T-001 (PendingEventBuffer + drain helper)
+  │
+  ├──▶ T-002 (manage state + .manage call in lib.rs)
+  │      │
+  │      └──▶ T-003 (single-instance callback rewrite)
+  │             │
+  │             └──▶ T-005 (invoke_handler entry + add module re-exports)
+  │
+  └──▶ T-004 (flush_pending_events command + unit tests in commands.rs)
+         │
+         └──▶ T-005 (invoke_handler entry)
+
+T-006 (resolve_and_emit logging) — depends on T-002 only because both
+                                   edit lib.rs; can be parallel with T-003
+                                   if regions don't overlap (they don't,
+                                   but for simplicity we sequence after T-005).
+
+T-007 (frontend invoke + verification) — depends on T-005 (backend complete)
+```
+
+## Parallel Execution Groups
+
+Group A (foundation): T-001
+Group B (after T-001): T-002, T-004 cannot fully parallelize because
+both add code to `lib.rs` test imports / signatures. Run sequentially.
+Group C (after T-005): T-006, T-007 are in different files (lib.rs vs App.tsx);
+T-007 can start once T-005 lands. T-006 is small Rust-only.
+
+Given the tight coupling, **we recommend serial execution** (T-001 → T-002 → T-003 → T-004 → T-005 → T-006 → T-007). The AO can still parallelize unit testing within tasks but tasks themselves are mostly sequential.
+
+## Tasks
+
+### T-001: Add `PendingEventBuffer` struct + `drain_pending_events` helper
+
+- **Description**:
+  - Define `pub struct PendingEventBuffer(pub Mutex<Vec<(String, String)>>);` with `#[derive(Default)]` in `src-tauri/src/lib.rs` (near other state structs at top of file).
+  - Define `pub(crate) fn drain_pending_events<F: FnMut(&str, String)>(buffer: &PendingEventBuffer, mut emit_fn: F)` in `src-tauri/src/lib.rs` — pure helper that locks the mutex, drains the buffer, and calls `emit_fn` for each entry. On poisoned mutex: skip silently.
+- **Files**: `src-tauri/src/lib.rs`
+- **Dependencies**: None
+- **Acceptance Criteria**:
+  - [ ] `PendingEventBuffer` compiles and implements `Default + Send + Sync`.
+  - [ ] `drain_pending_events` is `pub(crate)` so commands.rs can call it.
+  - [ ] No existing code is changed except adding the new struct + helper near top of file.
+  - [ ] `cargo build` succeeds warning-free.
+- **Tests**: Covered by T-004 (which imports and tests the helper).
+- **Effort**: Small
+
+### T-002: Register `PendingEventBuffer` state in `tauri::Builder`
+
+- **Description**:
+  - Insert `.manage(PendingEventBuffer::default())` in the builder chain in `run()` alongside the other `.manage(...)` calls (around line 163-165). Do **not** touch lines 119-129 or 246.
+- **Files**: `src-tauri/src/lib.rs`
+- **Dependencies**: T-001
+- **Acceptance Criteria**:
+  - [ ] `.manage(PendingEventBuffer::default())` is present in the builder chain.
+  - [ ] Builder chain still compiles.
+- **Tests**: Compile-time check via `cargo build`.
+- **Effort**: Small
+
+### T-003: Rewrite single-instance callback to buffer when window absent
+
+- **Description**:
+  - Modify `tauri_plugin_single_instance::init(...)` callback at lib.rs:183-191 per design.md:
+    - If `app.get_webview_window("main").is_some()` → call `resolve_and_emit(app, path)` (current).
+    - Else if `app.try_state::<PendingEventBuffer>()` is `Some` → lock mutex, push `("cli-open".to_string(), path.clone())`.
+    - Always attempt `set_focus()` when window exists (preserved).
+- **Files**: `src-tauri/src/lib.rs`
+- **Dependencies**: T-002
+- **Acceptance Criteria**:
+  - [ ] Callback handles both window-exists and window-absent cases.
+  - [ ] Uses `try_state` not `state` (no panic on missing state).
+  - [ ] Does not panic on poisoned mutex (`if let Ok(...)` guard).
+  - [ ] `cargo build` succeeds warning-free.
+- **Tests**: Code review + manual smoke test in T-007.
+- **Effort**: Small
+
+### T-004: Add `flush_pending_events` command + unit tests
+
+- **Description**:
+  - Add `#[tauri::command] pub fn flush_pending_events(app: tauri::AppHandle)` in `src-tauri/src/commands.rs`. Implementation per design.md: get state via `app.state::<crate::PendingEventBuffer>()`, call `crate::drain_pending_events(&state, |event, payload| { ... eprintln on err ... });`.
+  - Add unit tests in `src-tauri/src/commands.rs#tests` for `crate::drain_pending_events`:
+    1. `test_drain_pending_events_empty_buffer_is_noop`
+    2. `test_drain_pending_events_drains_in_fifo_order`
+    3. `test_drain_pending_events_drains_to_empty`
+    4. `test_drain_pending_events_poisoned_mutex_is_noop`
+- **Files**: `src-tauri/src/commands.rs`
+- **Dependencies**: T-001
+- **Acceptance Criteria**:
+  - [ ] Command compiles and is annotated `#[tauri::command]`.
+  - [ ] All four unit tests pass (`cargo test`).
+  - [ ] Poisoned-mutex test does not crash test runner.
+- **Tests**: 4 new unit tests as above.
+- **Effort**: Medium
+
+### T-005: Register `flush_pending_events` in `invoke_handler`
+
+- **Description**:
+  - Add `commands::flush_pending_events` to the `tauri::generate_handler![...]` list at lib.rs:166-181. Position at end of the list (alphabetical or last) — anywhere outside lines 119-129 and 246.
+- **Files**: `src-tauri/src/lib.rs`
+- **Dependencies**: T-003, T-004
+- **Acceptance Criteria**:
+  - [ ] `commands::flush_pending_events` appears in the macro invocation.
+  - [ ] `cargo build --release` succeeds warning-free.
+- **Tests**: Compile-time check.
+- **Effort**: Small
+
+### T-006: Log emit failures in `resolve_and_emit`
+
+- **Description**:
+  - At lib.rs:134-149, replace each `let _ = emitter.emit(...)` call with `if let Err(e) = emitter.emit(...) { eprintln!("Failed to emit <event_name> event: {}", e); }`. Apply to all three sites: raw fallback (`cli-open`), dir branch (`cli-open-dir`), file branch (`cli-open`).
+- **Files**: `src-tauri/src/lib.rs`
+- **Dependencies**: T-005 (sequential ordering only — disjoint region)
+- **Acceptance Criteria**:
+  - [ ] All three emit sites now log on `Err`.
+  - [ ] `cargo build` succeeds warning-free.
+  - [ ] Existing tests (if any reference this path) still pass.
+- **Tests**: Manual code review.
+- **Effort**: Small
+
+### T-007: Frontend — invoke `flush_pending_events` after listener registration
+
+- **Description**:
+  - In `src/App.tsx` `setupTauriListeners` (~line 224-272), after the three `listen(...)` calls complete (right before `onCleanup(...)`), add:
+    ```ts
+    await invoke("flush_pending_events").catch(() => {});
+    ```
+- **Files**: `src/App.tsx`
+- **Dependencies**: T-005 (backend command must exist)
+- **Acceptance Criteria**:
+  - [ ] Invoke happens after all three listeners are registered.
+  - [ ] `.catch(() => {})` is present (silent failure).
+  - [ ] TypeScript type-check passes (`bun run typecheck` or `tsc --noEmit`).
+  - [ ] No regression in `kusa file.md` (1st-instance) flow — manual smoke.
+- **Tests**: Manual smoke test:
+  - 1st instance: `kusa README.md` opens README.
+  - 2nd instance race: open kusa with one file, immediately open with another → 2nd file shows.
+- **Effort**: Small
+
+## File Conflict Matrix
+
+| Task | Files | Conflicts With |
+|------|-------|----------------|
+| T-001 | `src-tauri/src/lib.rs` (top: new struct+helper) | T-002, T-003, T-005, T-006 (same file) |
+| T-002 | `src-tauri/src/lib.rs` (builder chain ~163-165) | T-001, T-003, T-005, T-006 |
+| T-003 | `src-tauri/src/lib.rs` (callback 183-191) | T-001, T-002, T-005, T-006 |
+| T-004 | `src-tauri/src/commands.rs` | None |
+| T-005 | `src-tauri/src/lib.rs` (invoke_handler 166-181) | T-001, T-002, T-003, T-006 |
+| T-006 | `src-tauri/src/lib.rs` (134-149) | T-001, T-002, T-003, T-005 |
+| T-007 | `src/App.tsx` | None |
+
+## Constraint Compliance
+
+- All `lib.rs` edits land in the disjoint regions: top-of-file (struct), 134-149 (resolve_and_emit), 160-165 (.manage), 166-181 (invoke_handler), 183-191 (callback). **Lines 119-129 and 246 are untouched** (#69's region).
+- TDD: T-004 unit tests are written alongside / before the command implementation; the helper (T-001) is testable purely.
+- No `git commit --no-verify`.
+
+## Requirements Traceability
+
+| Requirement | Tasks |
+|-------------|-------|
+| FR-001 (PendingEventBuffer struct) | T-001 |
+| FR-002 (.manage) | T-002 |
+| FR-003 (command exposed) | T-004, T-005 |
+| FR-004 (drain in FIFO) | T-001, T-004 |
+| FR-005 (no panic poisoned mutex) | T-001 |
+| FR-010 (emit when window exists) | T-003 |
+| FR-011 (buffer when window absent) | T-003 |
+| FR-012 (set_focus preserved) | T-003 |
+| FR-013 (no panic missing state) | T-003 (try_state) |
+| FR-020 (log emit failures) | T-006 |
+| FR-030 (frontend invoke) | T-007 |
+| FR-031 (.catch) | T-007 |
+| FR-040 (no args → skip) | T-003 (existing guard preserved) |
+| FR-041 (multi-entry flush) | T-001, T-004 (test) |
+| FR-042 (empty flush no-op) | T-001, T-004 (test) |
+| FR-050 (continue on partial emit fail) | T-004 |
+| NFR-001/002 (perf) | T-001, T-002 |
+| NFR-010/011 (Mutex + no panic) | T-001, T-003, T-004 |
+| NFR-012 (no duplicate 1st-instance) | T-003 (callback-only push) |
+| NFR-020 (new unit tests) | T-004 |
+| NFR-021 (existing tests pass) | All tasks (validated at T-007) |
+| NFR-030 (warning-free) | All tasks (validated at T-007) |
+| NFR-031 (frontend type-check) | T-007 |
+| C-001 (avoid #69 regions) | All tasks (constraint compliance section) |
+| C-002 (no --no-verify) | Workflow contract |
+| C-003 (preserve resolve_and_emit signature) | T-006 |
+| C-004 (no auto-flush) | T-004 (drain only on invoke) |

--- a/src-tauri/src/commands.rs
+++ b/src-tauri/src/commands.rs
@@ -588,6 +588,24 @@ pub fn stop_file_watch(
     state.stop()
 }
 
+/// Flush any events buffered by the single-instance plugin callback
+/// before the frontend was ready to receive them. The frontend invokes
+/// this once after `setupTauriListeners` has registered all listeners.
+///
+/// See issue #70: the single-instance callback can fire before
+/// `tauri::Builder::setup()` completes (i.e. before the main window
+/// exists), so we buffer events instead of emitting them into the void.
+#[tauri::command]
+pub fn flush_pending_events(app: tauri::AppHandle) {
+    use tauri::{Emitter, Manager};
+    let state = app.state::<crate::PendingEventBuffer>();
+    crate::drain_pending_events(&state, |event, payload| {
+        if let Err(e) = app.emit(event, payload) {
+            eprintln!("Failed to emit {} from flush_pending_events: {}", event, e);
+        }
+    });
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -986,5 +1004,102 @@ mod tests {
     fn test_validate_key_too_long() {
         let long_key = "a".repeat(65);
         assert!(validate_key(&long_key).is_err());
+    }
+
+    // ---------------------------------------------------------------
+    // Tests for `drain_pending_events` (the pure helper that powers
+    // the `flush_pending_events` command). We test the helper directly
+    // because `tauri::AppHandle` is non-trivial to mock without a full
+    // Tauri runtime; the command is a one-line wrapper.
+    //
+    // See `crate::drain_pending_events` and `flush_pending_events`.
+    // ---------------------------------------------------------------
+
+    use crate::{drain_pending_events, PendingEventBuffer};
+    use std::sync::Arc;
+
+    #[test]
+    fn test_drain_pending_events_empty_buffer_is_noop() {
+        let buffer = PendingEventBuffer::default();
+        let mut calls: Vec<(String, String)> = Vec::new();
+        drain_pending_events(&buffer, |event, payload| {
+            calls.push((event.to_string(), payload));
+        });
+        assert!(calls.is_empty(), "no emits should occur for empty buffer");
+        let buf = buffer.0.lock().unwrap();
+        assert!(buf.is_empty(), "buffer must remain empty");
+    }
+
+    #[test]
+    fn test_drain_pending_events_drains_in_fifo_order() {
+        let buffer = PendingEventBuffer::default();
+        {
+            let mut buf = buffer.0.lock().unwrap();
+            buf.push(("cli-open".to_string(), "/path/a.md".to_string()));
+            buf.push(("cli-open".to_string(), "/path/b.md".to_string()));
+            buf.push(("cli-open".to_string(), "/path/c.md".to_string()));
+        }
+
+        let mut calls: Vec<(String, String)> = Vec::new();
+        drain_pending_events(&buffer, |event, payload| {
+            calls.push((event.to_string(), payload));
+        });
+
+        assert_eq!(calls.len(), 3);
+        assert_eq!(calls[0], ("cli-open".to_string(), "/path/a.md".to_string()));
+        assert_eq!(calls[1], ("cli-open".to_string(), "/path/b.md".to_string()));
+        assert_eq!(calls[2], ("cli-open".to_string(), "/path/c.md".to_string()));
+
+        let buf = buffer.0.lock().unwrap();
+        assert!(buf.is_empty(), "buffer must be empty after drain");
+    }
+
+    #[test]
+    fn test_drain_pending_events_drains_to_empty_even_if_closure_does_nothing() {
+        // Simulates a partial-failure scenario where the emit closure
+        // silently swallows entries. The buffer must still end up empty
+        // because `drain(..)` consumes all entries before the closure runs.
+        let buffer = PendingEventBuffer::default();
+        {
+            let mut buf = buffer.0.lock().unwrap();
+            buf.push(("cli-open".to_string(), "x".to_string()));
+            buf.push(("cli-open".to_string(), "y".to_string()));
+        }
+
+        drain_pending_events(&buffer, |_event, _payload| {
+            // pretend emit fails / does nothing
+        });
+
+        let buf = buffer.0.lock().unwrap();
+        assert!(
+            buf.is_empty(),
+            "buffer must be fully drained even if the emit closure is a no-op"
+        );
+    }
+
+    #[test]
+    fn test_drain_pending_events_poisoned_mutex_is_noop() {
+        // Poison the mutex by panicking inside the lock guard on a
+        // separate thread, then verify the drain helper does not panic.
+        let buffer = Arc::new(PendingEventBuffer::default());
+
+        let poisoner = Arc::clone(&buffer);
+        let _ = std::thread::spawn(move || {
+            let _guard = poisoner.0.lock().unwrap();
+            panic!("intentional poison");
+        })
+        .join();
+
+        // Mutex is now poisoned. The helper must NOT panic.
+        let mut calls: Vec<(String, String)> = Vec::new();
+        drain_pending_events(&buffer, |event, payload| {
+            calls.push((event.to_string(), payload));
+        });
+
+        // On poisoned mutex we skip silently: no calls made.
+        assert!(
+            calls.is_empty(),
+            "no emits should occur when mutex is poisoned"
+        );
     }
 }

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -22,6 +22,33 @@ pub struct CliArgsData {
 
 pub struct CliArgsState(pub Mutex<Option<CliArgsData>>);
 
+/// Buffers `(event_name, payload)` pairs emitted before the frontend
+/// is ready to receive them. Drained by the `flush_pending_events`
+/// command once the frontend has registered its Tauri event listeners.
+///
+/// See issue #70: `tauri_plugin_single_instance`'s callback can fire
+/// before `.setup()` completes, in which case the main webview window
+/// does not yet exist and any `emit` call would be dropped.
+#[derive(Default)]
+pub struct PendingEventBuffer(pub Mutex<Vec<(String, String)>>);
+
+/// Drain all buffered events from `PendingEventBuffer` and invoke
+/// `emit_fn` for each. On poisoned mutex, this is a silent no-op
+/// (we prefer to drop a few buffered events over panicking).
+///
+/// Extracted as a pure helper so it can be unit-tested without
+/// requiring a Tauri runtime / `AppHandle`.
+pub(crate) fn drain_pending_events<F>(buffer: &PendingEventBuffer, mut emit_fn: F)
+where
+    F: FnMut(&str, String),
+{
+    if let Ok(mut buf) = buffer.0.lock() {
+        for (event, payload) in buf.drain(..) {
+            emit_fn(&event, payload);
+        }
+    }
+}
+
 /// Determine PeekConfig from CLI args and stdin state.
 /// `screen_width` and `screen_height` are used for the "half" preset.
 fn resolve_peek_config(matches: &tauri_plugin_cli::Matches, screen_width: f64, screen_height: f64) -> PeekConfig {
@@ -136,15 +163,19 @@ fn resolve_and_emit<R: tauri::Runtime, E: Emitter<R>>(emitter: &E, raw_path: &st
     let canonical = match std::fs::canonicalize(&path) {
         Ok(p) => p,
         Err(_) => {
-            let _ = emitter.emit("cli-open", raw_path.to_string());
+            if let Err(e) = emitter.emit("cli-open", raw_path.to_string()) {
+                eprintln!("Failed to emit cli-open event: {}", e);
+            }
             return;
         }
     };
 
     if canonical.is_dir() {
-        let _ = emitter.emit("cli-open-dir", canonical.to_string_lossy().to_string());
-    } else {
-        let _ = emitter.emit("cli-open", canonical.to_string_lossy().to_string());
+        if let Err(e) = emitter.emit("cli-open-dir", canonical.to_string_lossy().to_string()) {
+            eprintln!("Failed to emit cli-open-dir event: {}", e);
+        }
+    } else if let Err(e) = emitter.emit("cli-open", canonical.to_string_lossy().to_string()) {
+        eprintln!("Failed to emit cli-open event: {}", e);
     }
 }
 
@@ -163,6 +194,7 @@ pub fn run() {
         .manage(WindowModeState::default())
         .manage(CliArgsState(Mutex::new(None)))
         .manage(watcher::FileWatcherState::default())
+        .manage(PendingEventBuffer::default())
         .invoke_handler(tauri::generate_handler![
             commands::read_file,
             commands::list_md_files,
@@ -178,11 +210,23 @@ pub fn run() {
             commands::get_cli_args,
             commands::start_file_watch,
             commands::stop_file_watch,
+            commands::flush_pending_events,
         ])
         .plugin(
             tauri_plugin_single_instance::init(|app, args, _cwd| {
+                // If a 2nd instance ships a path argument, we either emit
+                // it directly (window already exists) or buffer it for
+                // delivery once the frontend listeners are registered.
+                // See issue #70 — the single-instance callback can fire
+                // before `.setup()` completes the window builder.
                 if let Some(path) = args.get(1) {
-                    resolve_and_emit(app, path);
+                    if app.get_webview_window("main").is_some() {
+                        resolve_and_emit(app, path);
+                    } else if let Some(state) = app.try_state::<PendingEventBuffer>() {
+                        if let Ok(mut buf) = state.0.lock() {
+                            buf.push(("cli-open".to_string(), path.clone()));
+                        }
+                    }
                 }
                 if let Some(window) = app.get_webview_window("main") {
                     let _ = window.set_focus();

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -264,6 +264,12 @@ const App: Component = () => {
       }
     });
 
+    // Flush any events the backend buffered before listeners were ready.
+    // The single-instance plugin callback can fire before .setup() completes
+    // (issue #70), in which case it pushes onto PendingEventBuffer instead of
+    // emitting. Now that all listeners are registered, drain that buffer.
+    await invoke("flush_pending_events").catch(() => {});
+
     onCleanup(() => {
       unlistenDir();
       unlistenFile();


### PR DESCRIPTION
## Summary

Fixes the race condition where `tauri_plugin_single_instance`'s callback can fire before `tauri::Builder::setup()` completes — leaving `app.get_webview_window("main")` returning `None`, so `emit()` calls are silently dropped and 2nd-instance file opens are lost.

Approach: buffer events in process-global `PendingEventBuffer` when the window is absent, then drain via a new `flush_pending_events` Tauri command that the frontend invokes after all listeners are registered.

## Changes

- **`src-tauri/src/lib.rs`**
  - Add `PendingEventBuffer(Mutex<Vec<(String, String)>>)` struct + `pub(crate) drain_pending_events` pure helper.
  - Register `.manage(PendingEventBuffer::default())`.
  - Single-instance callback now branches on window presence: emit if present, push to buffer if absent. Uses `try_state` and guards against poisoned mutex.
  - `resolve_and_emit` now logs emit failures via `eprintln!` (previously silent).
- **`src-tauri/src/commands.rs`**
  - New `#[tauri::command] flush_pending_events(app: tauri::AppHandle)` — drains buffer and re-emits, logging any emit errors.
  - 4 new unit tests for `drain_pending_events` (FIFO drain, empty buffer, no-op closure, poisoned mutex).
- **`src/App.tsx`**
  - `setupTauriListeners` now invokes `flush_pending_events` (with `.catch(() => {})`) immediately after all three `listen()` calls resolve.

## Coordination with parallel issue #69

#69 edits `src-tauri/src/lib.rs` lines **119-129** (Full mode window builder) and **246** (`create_window` call site).
This PR edits lines **134-149** (resolve_and_emit), the `.manage()` chain, the `invoke_handler!` list, and **183-191** (single-instance callback). Disjoint regions — a 3-way merge should succeed.

## Test plan

- [x] `cargo test` — 43/43 pass, including 4 new tests for `drain_pending_events`
- [x] `cargo clippy --all-targets -- -D warnings` — clean
- [x] `cargo build` — warning-free
- [x] `bun run build` (tsc + vite) — type-check passes
- [x] Frontend test pre-existing failures (`markdown.test.ts`) are unrelated to this change (same 5 fail on main)
- [ ] Manual smoke: `kusa README.md`, then within ~100 ms run `kusa CHANGELOG.md` → CHANGELOG.md opens (race window)
- [ ] CodeRabbit review

## Known limitation (documented in design.md)

Buffered events always use `"cli-open"` as the event name. If a user passes a **directory** in the narrow race window, the frontend will try to open it as a file. The dominant case is file opens; directory args in the race window are very rare. Follow-up F-2 in `design.md` can address this if needed.

## Closes

Closes #70

🤖 Generated with [Claude Code](https://claude.com/claude-code)