### PR TITLE
fix(read_file): enforce 64MiB size limit to prevent OOM on huge files

### DIFF
--- a/.kiro/specs/fix-read-file-size-limit/design.md
+++ b/.kiro/specs/fix-read-file-size-limit/design.md
@@ -1,0 +1,185 @@
+# Technical Design: fix-read-file-size-limit
+
+## Document Info
+- Feature: fix-read-file-size-limit
+- Status: Draft
+- Created: 2026-05-27
+- Requirements: ./requirements.md
+- Related Issue: kaze-jp/kusa#72
+
+## Architecture Overview
+
+```
+┌──────────────────────────┐                ┌────────────────────────────────────┐
+│ Frontend (SolidJS)       │  invoke('read_file', path)                          │
+│  - openFile() / drop /   ├──────────────► │ Tauri Backend                      │
+│    CLI bootstrap         │                │  src-tauri/src/commands.rs         │
+└──────────────────────────┘                │                                    │
+                                            │   fn read_file(path) -> Result {   │
+                                            │     1. canonicalize(path)          │
+                                            │     2. metadata(canonical) ◄─ NEW  │
+                                            │     3. if len > MAX_FILE_SIZE      │
+                                            │          return Err("File too      │
+                                            │              large …")     ◄─ NEW  │
+                                            │     4. read_to_string(canonical)   │
+                                            │   }                                │
+                                            └────────────────────────────────────┘
+```
+
+唯一の追加処理は **「`read_to_string` を呼ぶ前に `metadata().len()` で size を確認し、`MAX_FILE_SIZE` 超過なら早期 `Err`」** という 1 ガード。アーキテクチャ的な複雑性は増えず、Rust 側を「最小限に保つ」プロジェクト原則と整合する。
+
+## Component Design
+
+### Component: `MAX_FILE_SIZE` (module-level constant)
+
+- **Purpose**: 読み込み可能な最大ファイルサイズを 64 MiB に固定する単一情報源。
+- **Location**: `src-tauri/src/commands.rs` (module top, 既存の `SKIP_DIRS` 定義近辺)。
+- **Dependencies**: なし (`std` 内のみ)。
+- **Interface**:
+  ```rust
+  /// Maximum file size accepted by `read_file` (64 MiB).
+  /// Files larger than this are rejected before being read into memory,
+  /// to prevent OOM panics from accidentally opening huge non-markdown files.
+  pub(crate) const MAX_FILE_SIZE: u64 = 64 * 1024 * 1024;
+  ```
+- **Rationale**: 定数化することでテストからも同じ値を参照でき、上限変更時の重複編集を防ぐ。`pub(crate)` でテストモジュール (`#[cfg(test)] mod tests` は同 crate 内) から参照可能。
+
+### Component: `read_file` (修正対象 Tauri command)
+
+- **Purpose**: フロントエンドからの「ファイルを開く」リクエストを受けて UTF-8 文字列を返す。今回サイズ上限ガードを追加する。
+- **Location**: `src-tauri/src/commands.rs:48-55` (既存ブロック差し替え)。
+- **Dependencies**: `std::fs` のみ (既存のまま)。新規 crate なし。
+- **Interface (変更後)**:
+  ```rust
+  #[tauri::command]
+  pub fn read_file(path: String) -> Result<String, String> {
+      let canonical = fs::canonicalize(&path)
+          .map_err(|e| format!("Cannot resolve path '{}': {}", path, e))?;
+
+      let metadata = fs::metadata(&canonical)
+          .map_err(|e| format!("Cannot stat file '{}': {}", canonical.display(), e))?;
+
+      if metadata.len() > MAX_FILE_SIZE {
+          return Err(format!(
+              "File too large: {} bytes (max {} bytes)",
+              metadata.len(),
+              MAX_FILE_SIZE
+          ));
+      }
+
+      fs::read_to_string(&canonical)
+          .map_err(|e| format!("Cannot read file '{}': {}", canonical.display(), e))
+  }
+  ```
+- **Rationale**:
+  - `metadata.len() > MAX_FILE_SIZE` で **strict greater than** を採用 (FR-021: equal は accept)。
+  - エラーメッセージは `"File too large: {actual} bytes (max {max} bytes)"` の形式 (FR-032 を満たす)。
+  - `canonicalize` で path-traversal を引き続き解決し、その後の `metadata` も canonical path を使う (シンボリックリンクが指す実体のサイズを確認できる)。
+  - `unwrap`/`expect` を一切使わず `?` と `map_err` で error 伝搬 (FR-033)。
+
+## API Contracts
+
+### Tauri command: `read_file`
+
+- **Signature**: `fn read_file(path: String) -> Result<String, String>` (変更なし)
+- **Input**:
+  - `path: String` — フロントエンドから渡される任意のファイルパス。canonical 化前は相対パス・シンボリックリンクを含み得る。
+- **Output**: `Ok(String)` — ファイルの UTF-8 内容。
+- **Errors** (すべて `Err(String)` を返す、`panic` しない):
+  | ケース | メッセージ形式 |
+  |---|---|
+  | canonicalize 失敗 (FR-030) | `"Cannot resolve path '<path>': <io_error>"` |
+  | metadata 取得失敗 (FR-031) | `"Cannot stat file '<canonical>': <io_error>"` |
+  | サイズ超過 (FR-032) | `"File too large: <actual> bytes (max <max> bytes)"` |
+  | 読み込み失敗 (UTF-8 不正等) | `"Cannot read file '<canonical>': <io_error>"` (既存挙動) |
+- **Example**:
+  ```ts
+  // Frontend
+  const content = await invoke<string>('read_file', { path: '/path/to/file.md' });
+  // 64 MiB 超過時:
+  //   Error: "File too large: 67108865 bytes (max 67108864 bytes)"
+  ```
+
+## Data Models
+
+このフィーチャは新規データモデルを導入しない。利用するのは `std::fs::Metadata` (既存型) のみで、参照するのは `len() -> u64` のみ。
+
+## State Management
+
+新規 state なし。`MAX_FILE_SIZE` は **コンパイル時定数**であり実行時 mutable state を生まない。
+
+## Error Handling Strategy
+
+- **エラーカテゴリ**: 既存の I/O エラー (path 解決失敗・読み込み失敗) に加え、**サイズ超過エラー**を新規追加。
+- **回復戦略**: backend は `Err(String)` を返すのみ。フロントエンドは既存の `invoke` エラーパスでトースト/モーダル表示する (今回フロントエンド変更なし)。
+- **メッセージ設計**: ユーザが「なぜ開けなかったのか」を即理解できるよう、`File too large` の語と実サイズ・上限を出す。バイト数は人間可読性より機械可読性 (ログ・テスト assert) を優先して `bytes` 単位で出力。
+- **panic 禁止**: `?`, `map_err`, `if` による early return のみを使用。
+
+## Testing Strategy
+
+### Unit test targets (`src-tauri/src/commands.rs` の `#[cfg(test)] mod tests` 内)
+
+| Test name | 目的 | 期待結果 |
+|---|---|---|
+| `test_read_file_success` (既存) | 正常な markdown ファイルが読める | `Ok(contents)` (壊さない) |
+| `test_read_file_not_found` (既存) | 存在しないパスは `Err` | `Err`(`Cannot resolve path`) (壊さない) |
+| `test_read_file_non_md` (既存) | 拡張子非 md でも本コマンドは読める | `Ok(contents)` (壊さない、本機能は extension チェックしない) |
+| `test_read_file_oversize` (**新規**) | `MAX_FILE_SIZE + 1` バイトのファイルは reject | `Err` で `"File too large"` を含み、`Cannot read file` を含まないこと (= `read_to_string` まで到達していない) |
+
+### TDD 手順 (実装フェーズで厳守)
+
+1. `test_read_file_oversize` を**先に書く** → `cargo test test_read_file_oversize` で **red** を確認。
+2. `MAX_FILE_SIZE` 定数 + size check ブロックを `read_file` に追加。
+3. `cargo test` 全体で **green** を確認 (既存 3 テスト含む)。
+
+### テストフィクスチャ生成
+
+```rust
+use std::fs::File;
+let tmp = tempfile::tempdir().unwrap();
+let path = tmp.path().join("huge.md");
+let f = File::create(&path).unwrap();
+f.set_len(MAX_FILE_SIZE + 1).unwrap();  // sparse file: 物理サイズはほぼ 0
+```
+
+- `tempfile` crate は既に dev-dependency として使われている (既存テスト群が利用) ことを前提。利用していなければ既存テストの fixture 生成方式 (`std::env::temp_dir()` + 一意名) に揃える。
+- `set_len` により論理サイズだけ拡張される sparse file が作られ、テスト実行コストはミリ秒オーダー。
+
+### Edge cases to cover
+
+- Boundary at `MAX_FILE_SIZE` (== ちょうど 64 MiB): 受理されること — **本フィーチャでは新規テストを追加しない** (テスト中に 64MiB sparse + read_to_string まで実行すると遅くなる)。代わりに `>` 演算子の選択を design で明示し、コードレビューで担保する。
+- `metadata` 失敗ケース: 既存の path-not-found テストが `canonicalize` で先に失敗するためカバー済み。`metadata` 単独失敗は OS 依存で再現困難なため明示テストは不要 (FR-031 はコード経路の存在で satisfy)。
+
+## Security Considerations
+
+- **DoS 緩和**: 巨大ファイル投入による OOM-kill を防ぐことで、kusa プロセスのクラッシュ耐性が向上する (NFR-011)。
+- **シンボリックリンクハンドリング**: `canonicalize` で解決した後の実体に対して `metadata` を呼ぶため、symlink を介した「小さく見えるが実体は巨大」な攻撃ベクトルを防げる。
+- **情報漏洩**: エラーメッセージに canonical path が含まれるが、これは既存挙動と同じ。フロントエンド側は信頼境界内のため問題なし。
+
+## Performance Impact
+
+- 正常ケース (< 64 MiB): `fs::metadata` 1 回 (≈ μ秒オーダー) が追加。NFR-001/NFR-002 を満たす。
+- 超過ケース: `read_to_string` を完全に回避するため、従来 OOM/long-stall していたケースが μ秒で `Err` を返すように改善。NFR-003 を満たす。
+
+## Requirements Traceability
+
+| Requirement | Design element |
+|---|---|
+| FR-001 (`MAX_FILE_SIZE` 定数) | Component: `MAX_FILE_SIZE` |
+| FR-002 (canonicalize 先行) | `read_file` Step 1 |
+| FR-003 (metadata 先行) | `read_file` Step 2 |
+| FR-004 (上限以内は read_to_string で返す) | `read_file` Step 4 |
+| FR-020 (上限超過は `Err` で `read_to_string` を呼ばない) | `read_file` Step 3 (early return) |
+| FR-021 (boundary inclusive) | `>` 演算子の選択 |
+| FR-022 (sparse logical len も reject) | `metadata().len()` 利用 (logical size 取得) |
+| FR-030 (canonicalize 失敗 Err) | 既存 `map_err` 保持 |
+| FR-031 (metadata 失敗 Err) | 新規 `map_err("Cannot stat file ...")` |
+| FR-032 (Err 文言: "File too large" + sizes) | `format!("File too large: {} bytes (max {} bytes)", ..)` |
+| FR-033 (panic 禁止) | `?` / `map_err` / `if` only |
+| NFR-001/002/003 (perf, single stat) | `fs::metadata` 1 回追加 |
+| NFR-010/011 (reliability) | size guard + canonical handling |
+| NFR-020 (シグネチャ不変) | `fn(path: String) -> Result<String, String>` 維持 |
+| NFR-021 (新規依存なし) | `std::fs` のみ |
+| NFR-030 (Tauri runtime 不要のテスト) | `#[cfg(test)] mod tests` で完結 |
+| NFR-031 (sparse file fixture) | Testing Strategy セクション |
+| Acceptance #1-7 | 上記全て + 修正範囲が `commands.rs` 1 ファイル |

--- a/.kiro/specs/fix-read-file-size-limit/requirements-init.md
+++ b/.kiro/specs/fix-read-file-size-limit/requirements-init.md
@@ -1,0 +1,46 @@
+# Feature: fix-read-file-size-limit
+
+## Overview
+
+`read_file` Tauri command にファイルサイズ上限 (64MB) を追加し、巨大ファイルを開いた際に OOM panic / フリーズが起きないようにする。誤って video / log / 大規模 JSON 等を `.md` として開くケースや、本当に巨大な markdown を開くケースで kusa プロセスがクラッシュする問題を防ぐ。
+
+## Product Context
+
+kusa は「Markdown を読む/書く/レビューする体験を再定義する軽量・高速エディター」であり、CLI 起動・ドラッグ&ドロップ・ファイルピッカーを介したファイルオープンが Instant Open の中核体験。読み込み経路がクラッシュすると即 UX を毀損するため、信頼性の確保は P0 級の安定性課題である。
+
+(`.ao/steering/product.md` は現状テンプレートのままで具体的記述なし。プロダクト原則「軽量・高速・即起動」を前提に判断する。)
+
+## Initial Requirements
+
+### Functional Requirements
+
+- **FR-001**: The `read_file` command shall enforce a maximum file size of 64 MiB (`64 * 1024 * 1024` bytes) before reading file contents.
+- **FR-002**: When the target file's size exceeds the maximum, the `read_file` command shall return an `Err` containing a human-readable message including the actual file size and the configured maximum.
+- **FR-003**: When the target file's size is within the maximum, the `read_file` command shall return its UTF-8 contents as today (behavior preservation).
+- **FR-004**: If file metadata cannot be obtained (e.g. permission error after canonicalize), the `read_file` command shall return an `Err` with an explanatory message rather than panicking.
+
+### Non-Functional Requirements
+
+- **NFR-001**: The `read_file` command shall perform the size check using `fs::metadata().len()` to avoid loading file contents into memory before validation.
+- **NFR-002**: The `read_file` command's size check shall add negligible latency (single stat syscall) for normal-sized markdown files.
+- **NFR-003**: The implementation shall not introduce additional dependencies.
+- **NFR-004**: The implementation shall not change the public Tauri command signature (`fn(path: String) -> Result<String, String>`), so frontend callers require no changes.
+
+### Constraints
+
+- 修正対象は **`src-tauri/src/commands.rs` のみ**。
+- 上限は **`MAX_FILE_SIZE = 64 * 1024 * 1024` (64 MiB)** に固定 (markdown 用途として十分大きい)。
+- 既存テスト 3 件 (`test_read_file_success`, `test_read_file_not_found`, `test_read_file_non_md`) を破壊しない。
+- 新規テスト `test_read_file_oversize` を **TDD で先に書き red → green** を確認する。
+- 拡張子チェック (.md 以外を弾く) と async 化はスコープ外。
+- `git commit --no-verify` 禁止。Conventional Commits を遵守。
+
+### Assumptions
+
+- `fs::File::set_len(MAX_FILE_SIZE + 1)` で生成した sparse file の `metadata().len()` は論理サイズ (`MAX_FILE_SIZE + 1`) を返す (macOS APFS / Linux ext4 等で標準動作)。これによりテストファイルを実際に 64MB+ 書き込まずに作成可能。
+- フロントエンドは `read_file` の `Err` を既にトースト/エラーメッセージとして表示できる経路を持っている (今回は backend だけで十分)。
+- ファイル読み込み中の中断は不要 (size check 失敗時は即 `Err` を返すだけ)。
+
+### Open Questions
+
+- なし。issue #72 で fix の方針 (size check 追加・テスト追加・extension チェックと async はスコープ外) が確定済み。

--- a/.kiro/specs/fix-read-file-size-limit/requirements.md
+++ b/.kiro/specs/fix-read-file-size-limit/requirements.md
@@ -1,0 +1,83 @@
+# Requirements: fix-read-file-size-limit
+
+## Document Info
+- Feature: fix-read-file-size-limit
+- Status: Draft
+- Created: 2026-05-27
+- Related Issue: kaze-jp/kusa#72
+
+## Overview
+
+`read_file` Tauri command にファイルサイズ上限 (64 MiB) のガードを追加し、巨大ファイル (動画・ログ・大規模 JSON など、誤って `.md` として開かれるケースを含む) を読み込もうとした際に kusa プロセスがメモリ枯渇・panic・フリーズすることを防ぐ。修正は backend のみで完結し、フロントエンドの呼び出し側は変更を要さない。
+
+## Functional Requirements
+
+### Core Behavior
+
+- **FR-001**: The `read_file` command shall define a compile-time constant `MAX_FILE_SIZE` equal to `64 * 1024 * 1024` bytes (64 MiB).
+- **FR-002**: When `read_file` is invoked with a `path`, the command shall canonicalize the path before any further processing.
+- **FR-003**: After canonicalization succeeds, the `read_file` command shall query the file's metadata via `fs::metadata` to obtain its size **before** invoking `fs::read_to_string`.
+- **FR-004**: When the metadata-reported file size is less than or equal to `MAX_FILE_SIZE`, the `read_file` command shall read and return the file contents as a UTF-8 `String` (existing behavior is preserved).
+
+### Edge Cases
+
+- **FR-020**: When the metadata-reported file size is strictly greater than `MAX_FILE_SIZE`, the `read_file` command shall return `Err(...)` **without** calling `fs::read_to_string`.
+- **FR-021**: When the metadata-reported file size equals exactly `MAX_FILE_SIZE`, the `read_file` command shall accept the file and return its contents (boundary is inclusive at the maximum).
+- **FR-022**: If the file is a sparse file whose logical size (as reported by `metadata().len()`) exceeds `MAX_FILE_SIZE`, the `read_file` command shall reject it via FR-020 regardless of on-disk physical size.
+
+### Error Handling
+
+- **FR-030**: If `fs::canonicalize` fails, the `read_file` command shall return `Err` containing the original `path` and the underlying error (existing behavior preserved).
+- **FR-031**: If `fs::metadata` fails after canonicalization succeeds, the `read_file` command shall return `Err` containing the canonical path display and the underlying error.
+- **FR-032**: When the file exceeds `MAX_FILE_SIZE`, the returned `Err` string shall include the literal phrase `"File too large"`, the actual byte count, and the maximum byte count, in a single human-readable line.
+- **FR-033**: The `read_file` command shall never `panic!`, `unwrap`, or `expect` on user-controlled input.
+
+## Non-Functional Requirements
+
+### Performance
+
+- **NFR-001**: The size-check path shall add no more than one additional stat syscall (`fs::metadata`) compared to today's implementation.
+- **NFR-002**: For normal-sized markdown files (< 1 MiB), the added overhead shall be negligible (< 1 ms on modern hardware).
+- **NFR-003**: When the size check rejects a file, the command shall return without allocating a `String` for the file contents.
+
+### Reliability
+
+- **NFR-010**: The `read_file` command shall remain panic-free for arbitrary `path` inputs (existing path-traversal canonical-check behavior preserved by FR-002).
+- **NFR-011**: The `read_file` command shall not enter unbounded memory allocation for any input on disk, regardless of file size.
+
+### Compatibility
+
+- **NFR-020**: The public Tauri command signature shall remain `fn read_file(path: String) -> Result<String, String>`; no frontend changes are required.
+- **NFR-021**: The implementation shall not add any new crate to `src-tauri/Cargo.toml`.
+
+### Testability
+
+- **NFR-030**: The implementation shall be unit-testable via Rust's built-in `#[cfg(test)]` module without requiring a running Tauri runtime.
+- **NFR-031**: Test fixtures for the oversize case shall be creatable as sparse files via `fs::File::set_len(MAX_FILE_SIZE + 1)` to avoid disk-space cost.
+
+## Acceptance Criteria
+
+1. `MAX_FILE_SIZE` is defined as `64 * 1024 * 1024` at module scope in `src-tauri/src/commands.rs`.
+2. `read_file` rejects files strictly larger than `MAX_FILE_SIZE` with an `Err` containing `"File too large"`, the actual size, and the configured maximum.
+3. `read_file` continues to return file contents for files at or below `MAX_FILE_SIZE` (existing happy-path tests stay green).
+4. A new unit test `test_read_file_oversize` is added; it creates a sparse file of `MAX_FILE_SIZE + 1` bytes and asserts that `read_file` returns an `Err` whose message contains `"File too large"`.
+5. All existing tests pass (`cargo test` in `src-tauri/`): `test_read_file_success`, `test_read_file_not_found`, `test_read_file_non_md`, plus every other existing test in the crate.
+6. No additional dependency is added to `src-tauri/Cargo.toml`.
+7. The implementation lives entirely within `src-tauri/src/commands.rs` (other source files unchanged).
+
+## Traceability
+
+| requirements-init.md | requirements.md |
+|---|---|
+| FR-001 (size 上限定数 + check)         | FR-001, FR-003, FR-020 |
+| FR-002 (size 超過時 Err with detail)   | FR-020, FR-032 |
+| FR-003 (上限以内では今と同じ動作)        | FR-004 |
+| FR-004 (metadata 失敗時 Err, panic 禁止) | FR-031, FR-033, NFR-010 |
+| NFR-001 (`fs::metadata().len()` 使用)   | FR-003, NFR-001, NFR-003 |
+| NFR-002 (通常 markdown で遅延ほぼ無)     | NFR-002 |
+| NFR-003 (新規依存なし)                  | NFR-021 |
+| NFR-004 (公開シグネチャ不変)             | NFR-020 |
+| Constraint (修正は commands.rs のみ)     | Acceptance Criteria #7 |
+| Constraint (既存 3 テスト破壊禁止)        | Acceptance Criteria #5 |
+| Constraint (TDD で新規 oversize test 追加) | Acceptance Criteria #4 |
+| Assumption (sparse file の logical len)   | FR-022, NFR-031 |

--- a/.kiro/specs/fix-read-file-size-limit/spec.json
+++ b/.kiro/specs/fix-read-file-size-limit/spec.json
@@ -1,0 +1,22 @@
+{
+  "feature_name": "fix-read-file-size-limit",
+  "created_at": "2026-05-27T00:00:00Z",
+  "updated_at": "2026-05-27T00:00:00Z",
+  "language": "ja",
+  "phase": "implementing",
+  "approvals": {
+    "requirements": {
+      "generated": true,
+      "approved": true
+    },
+    "design": {
+      "generated": true,
+      "approved": true
+    },
+    "tasks": {
+      "generated": true,
+      "approved": true
+    }
+  },
+  "ready_for_implementation": true
+}

--- a/.kiro/specs/fix-read-file-size-limit/tasks.md
+++ b/.kiro/specs/fix-read-file-size-limit/tasks.md
@@ -1,0 +1,116 @@
+# Implementation Tasks: fix-read-file-size-limit
+
+## Document Info
+- Feature: fix-read-file-size-limit
+- Total tasks: 4
+- Parallelizable: 0 (全タスクが `src-tauri/src/commands.rs` の同一領域を触るため逐次実行)
+- Created: 2026-05-27
+- Related Issue: kaze-jp/kusa#72
+
+## Task Dependency Graph
+
+```
+T-001 (red test) ──► T-002 (impl: const + size guard) ──► T-003 (green verify) ──► T-004 (commit & PR)
+```
+
+すべて同じファイル (`src-tauri/src/commands.rs`) を編集するため、論理的に **逐次実行のみ**。並列化グループは存在しない。
+
+## Parallel Execution Groups
+
+- **Group 1 (serial)**: T-001 → T-002 → T-003 → T-004
+
+## Tasks
+
+### T-001: Add failing oversize unit test (TDD red)
+
+- **Description**: `#[cfg(test)] mod tests` に `test_read_file_oversize` を追加する。`tempfile::TempDir` 内に sparse file (`MAX_FILE_SIZE + 1` バイト) を `File::create` + `set_len` で作成し、`read_file` を呼び出して `Err` が返ること & そのメッセージに `"File too large"` を含むことを assert する。**この時点ではまだ `MAX_FILE_SIZE` 定数も size check 実装も追加しない**ため、テストは初期状態では存在しない定数を参照しコンパイルエラーになる。
+- **Files**: `src-tauri/src/commands.rs` (test モジュールのみ)
+- **Dependencies**: None
+- **Acceptance Criteria**:
+  - [ ] `test_read_file_oversize` テスト関数が `#[cfg(test)] mod tests` 内に追加されている。
+  - [ ] テストは sparse file (`set_len(MAX_FILE_SIZE + 1)`) を fixture として使う。
+  - [ ] `assert!(result.is_err())` と `assert!(err.contains("File too large"))` を含む。
+  - [ ] (Red 確認) `MAX_FILE_SIZE` 未定義 or size guard 未実装の状態で `cargo test test_read_file_oversize` が **失敗** する (TDD red)。
+- **Tests**: 自身がテスト追加タスク。
+- **Effort**: Small
+
+### T-002: Add `MAX_FILE_SIZE` constant + size-check in `read_file`
+
+- **Description**: `commands.rs` モジュール上部に `pub(crate) const MAX_FILE_SIZE: u64 = 64 * 1024 * 1024;` を追加。`read_file` 関数本体に `fs::metadata` 呼び出しと `metadata.len() > MAX_FILE_SIZE` の early-return ガードを追加する (`Err` 文言は `"File too large: {} bytes (max {} bytes)"`)。`canonicalize` および最終の `fs::read_to_string` は維持。
+- **Files**: `src-tauri/src/commands.rs` (production code 部分)
+- **Dependencies**: T-001
+- **Acceptance Criteria**:
+  - [ ] `MAX_FILE_SIZE` 定数が `pub(crate) const` で定義され、値は `64 * 1024 * 1024`。
+  - [ ] `read_file` 関数に `fs::metadata(&canonical)` 呼び出しが入り、失敗時は `"Cannot stat file '...': ..."` を返す。
+  - [ ] サイズ超過判定が `metadata.len() > MAX_FILE_SIZE` (strict greater than) で実装されている。
+  - [ ] 超過時の `Err` 文言が `"File too large: {actual} bytes (max {max} bytes)"` フォーマット。
+  - [ ] 関数の戻り値型・シグネチャ (`fn(path: String) -> Result<String, String>`) は変更されていない。
+  - [ ] `unwrap()`, `expect()`, `panic!()` を新規追加していない。
+- **Tests**: T-003 で全体テスト実行。
+- **Effort**: Small
+
+### T-003: Verify all tests green & no regressions
+
+- **Description**: `cd src-tauri && cargo test` を実行し、新規 `test_read_file_oversize` を含むすべてのテストが pass することを確認。既存 `test_read_file_success`, `test_read_file_not_found`, `test_read_file_non_md` も green であることを確認。さらに `cargo clippy --all-targets -- -D warnings` および `cargo fmt -- --check` (もしプロジェクト hook で必要なら) を実行して lint clean を確認。
+- **Files**: なし (verification only)
+- **Dependencies**: T-002
+- **Acceptance Criteria**:
+  - [ ] `cargo test` が成功 (failed: 0)。
+  - [ ] `test_read_file_oversize`, `test_read_file_success`, `test_read_file_not_found`, `test_read_file_non_md` の 4 件がすべて pass。
+  - [ ] `cargo clippy` が warning 0 (もしくは新規 warning なし)。
+  - [ ] `cargo fmt --check` が clean (フォーマットの逸脱なし)。
+- **Tests**: 既存テストスイート全体。
+- **Effort**: Small
+
+### T-004: Commit, push, open PR with `Closes #72`
+
+- **Description**: spec ファイル (`requirements-init.md`, `requirements.md`, `design.md`, `tasks.md`) と実装 (`src-tauri/src/commands.rs`) を Conventional Commits 形式でコミット → push → GitHub PR 作成。PR body には `Closes #72` を含め、`solo-full-auto` プリセットに従い CodeRabbit レビュー要請まで自動で進める。
+- **Files**: なし (git/gh のみ; `--no-verify` 禁止)
+- **Dependencies**: T-003
+- **Acceptance Criteria**:
+  - [ ] Conventional Commits 形式のコミットメッセージ (例: `fix: enforce 64MB size limit in read_file command (closes #72)`)。
+  - [ ] `git commit --no-verify` を使っていない。
+  - [ ] PR が open され、本文に `Closes #72` を含む。
+  - [ ] PR description に変更概要・テスト結果が記載されている。
+- **Tests**: PR の CI が green。
+- **Effort**: Small
+
+## File Conflict Matrix
+
+| Task | Files | Conflicts With |
+|------|-------|---------------|
+| T-001 | `src-tauri/src/commands.rs` (test mod) | T-002 (同一ファイル) |
+| T-002 | `src-tauri/src/commands.rs` (top + read_file) | T-001 (同一ファイル) |
+| T-003 | なし (verification) | None |
+| T-004 | なし (git/gh) | None |
+
+→ T-001 と T-002 は同一ファイルを編集するため逐次実行のみ。並列実行可能なタスクなし。
+
+## Requirements Traceability
+
+| Requirement | Tasks |
+|------------|-------|
+| FR-001 (`MAX_FILE_SIZE` 定数) | T-002 |
+| FR-002 (canonicalize 先行) | T-002 (既存維持) |
+| FR-003 (metadata 先行取得) | T-002 |
+| FR-004 (上限以内は contents 返却) | T-002 (既存維持), T-003 (`test_read_file_success` で検証) |
+| FR-020 (上限超過は early `Err`) | T-001 (red), T-002 (実装), T-003 (green) |
+| FR-021 (boundary inclusive) | T-002 (`>` 演算子の選択) |
+| FR-022 (sparse logical len reject) | T-001 (sparse fixture でテスト), T-002 (`metadata().len()` で判定) |
+| FR-030 (canonicalize 失敗 Err) | T-002 (既存維持), T-003 (`test_read_file_not_found` で検証) |
+| FR-031 (metadata 失敗 Err) | T-002 |
+| FR-032 (Err 文言: "File too large" + sizes) | T-001 (assert), T-002 (format!) |
+| FR-033 (panic 禁止) | T-002 (`?` + `map_err` のみ) |
+| NFR-001/002/003 (perf, single stat) | T-002 |
+| NFR-010/011 (reliability) | T-002 |
+| NFR-020 (signature 不変) | T-002 |
+| NFR-021 (新規依存なし) | T-002 (使うのは `std::fs` のみ) |
+| NFR-030 (Tauri runtime 不要のテスト) | T-001 |
+| NFR-031 (sparse file fixture) | T-001 |
+| Acceptance #1 (定数定義) | T-002 |
+| Acceptance #2 (超過時 Err 文言) | T-001, T-002 |
+| Acceptance #3 (既存挙動維持) | T-003 |
+| Acceptance #4 (oversize test 追加) | T-001 |
+| Acceptance #5 (全テスト pass) | T-003 |
+| Acceptance #6 (依存追加なし) | T-002 |
+| Acceptance #7 (commands.rs 1 ファイルのみ) | T-001, T-002 |

--- a/src-tauri/src/commands.rs
+++ b/src-tauri/src/commands.rs
@@ -11,6 +11,13 @@ use walkdir::WalkDir;
 use crate::window_presets::FULL_SIZE;
 use crate::WindowModeState;
 
+/// Maximum file size accepted by `read_file` (64 MiB).
+///
+/// Files larger than this are rejected before being read into memory,
+/// to prevent OOM panics from accidentally opening huge non-markdown
+/// files (videos, logs, large JSON, etc.) via the `.md` association.
+pub(crate) const MAX_FILE_SIZE: u64 = 64 * 1024 * 1024;
+
 /// Directories to skip during recursive traversal.
 const SKIP_DIRS: &[&str] = &[
     ".git",
@@ -49,6 +56,17 @@ pub struct StdinState {
 pub fn read_file(path: String) -> Result<String, String> {
     let canonical = fs::canonicalize(&path)
         .map_err(|e| format!("Cannot resolve path '{}': {}", path, e))?;
+
+    let metadata = fs::metadata(&canonical)
+        .map_err(|e| format!("Cannot stat file '{}': {}", canonical.display(), e))?;
+
+    if metadata.len() > MAX_FILE_SIZE {
+        return Err(format!(
+            "File too large: {} bytes (max {} bytes)",
+            metadata.len(),
+            MAX_FILE_SIZE
+        ));
+    }
 
     fs::read_to_string(&canonical)
         .map_err(|e| format!("Cannot read file '{}': {}", canonical.display(), e))
@@ -621,6 +639,23 @@ mod tests {
         let result = read_file(file_path.to_string_lossy().to_string());
         assert!(result.is_ok());
         assert_eq!(result.unwrap(), "plain text content");
+    }
+
+    #[test]
+    fn test_read_file_oversize() {
+        // Use a sparse file (`set_len`) so we don't actually write 64MiB+ to disk.
+        let dir = TempDir::new().unwrap();
+        let file_path = dir.path().join("huge.md");
+        let file = fs::File::create(&file_path).unwrap();
+        file.set_len(MAX_FILE_SIZE + 1).unwrap();
+
+        let result = read_file(file_path.to_string_lossy().to_string());
+        assert!(result.is_err(), "expected Err for oversize file");
+        let err = result.unwrap_err();
+        assert!(
+            err.contains("File too large"),
+            "error message should contain 'File too large', got: {err}"
+        );
     }
 
     #[test]


### PR DESCRIPTION
## Summary

Fix for #72. The `read_file` Tauri command had no size cap, so opening a huge non-markdown file (video, log, large JSON, etc.) via the `.md` association — or genuinely huge markdown — could OOM-panic / freeze kusa because `fs::read_to_string` internally `String::with_capacity(file_size)`s the whole file.

This PR adds a single guard before the read:

- New `pub(crate) const MAX_FILE_SIZE: u64 = 64 * 1024 * 1024` (64 MiB) at module scope in `src-tauri/src/commands.rs`.
- `read_file` now calls `fs::metadata(&canonical)` between canonicalize and `read_to_string`, returning `Err("File too large: <N> bytes (max <M> bytes)")` if `metadata.len() > MAX_FILE_SIZE`.
- Strict greater-than: a file of exactly 64 MiB is still accepted; anything larger is rejected before any allocation.
- Public Tauri command signature (`fn(path: String) -> Result<String, String>`) is unchanged → no frontend changes required.
- No new crate dependency; `std::fs` only.

Scope is limited to `src-tauri/src/commands.rs` as the issue requests. Extension filtering and async I/O are out of scope.

## Diff highlights

```rust
pub(crate) const MAX_FILE_SIZE: u64 = 64 * 1024 * 1024;

#[tauri::command]
pub fn read_file(path: String) -> Result<String, String> {
    let canonical = fs::canonicalize(&path)
        .map_err(|e| format!("Cannot resolve path '{}': {}", path, e))?;

    let metadata = fs::metadata(&canonical)
        .map_err(|e| format!("Cannot stat file '{}': {}", canonical.display(), e))?;

    if metadata.len() > MAX_FILE_SIZE {
        return Err(format!(
            "File too large: {} bytes (max {} bytes)",
            metadata.len(),
            MAX_FILE_SIZE
        ));
    }

    fs::read_to_string(&canonical)
        .map_err(|e| format!("Cannot read file '{}': {}", canonical.display(), e))
}
```

## Test plan

- [x] New unit test `test_read_file_oversize` — creates a sparse file with `File::set_len(MAX_FILE_SIZE + 1)`, asserts `read_file` returns `Err` whose message contains `"File too large"`.
- [x] TDD: wrote the test first; verified compile error (red) before adding `MAX_FILE_SIZE` + guard; then verified all tests pass (green).
- [x] Existing tests preserved and passing: `test_read_file_success`, `test_read_file_not_found`, `test_read_file_non_md`.
- [x] `cargo test` in `src-tauri/` → 40 passed, 0 failed.
- [x] `cargo clippy --all-targets -- -D warnings` → clean.
- [x] No new `cargo fmt` diffs introduced (22 pre-existing diffs in unrelated files unchanged).
- [x] No new `bun test` failures introduced (5 pre-existing `processMarkdown` frontend failures are unrelated to this Rust change).

## Spec

Full SDD spec lives under `.kiro/specs/fix-read-file-size-limit/` (requirements, design, tasks). Tracked separately in the `docs:` commit.

Closes #72