### PR TITLE
fix(cli): handle relaunch spawn failure and harden app path extraction

### DIFF
--- a/.kiro/specs/fix-cli-relaunch-spawn/design.md
+++ b/.kiro/specs/fix-cli-relaunch-spawn/design.md
@@ -1,0 +1,254 @@
+# Technical Design: fix-cli-relaunch-spawn
+
+## Document Info
+
+- Feature: fix-cli-relaunch-spawn
+- Status: Draft (auto-approved via `-y`)
+- Created: 2026-05-27
+- Requirements: ./requirements.md
+- Linked Issue: #68
+
+## Architecture Overview
+
+This is a localized fix to the macOS release-build relaunch path in `src-tauri/src/main.rs`.
+No new architectural layers, no new files, no new crate dependencies. The change rewrites the existing block guarded by `#[cfg(all(not(debug_assertions), target_os = "macos"))]` so it (a) extracts the `.app/` path via `rfind`, (b) validates the candidate by canonicalization, and (c) handles `Command::spawn()` failure by falling through to `kusa_lib::run()` with stderr diagnostics.
+
+```text
+                        kusa <file>  (CLI invocation)
+                              │
+                              ▼
+                ┌─────────────────────────────┐
+                │   main()                    │
+                └─────────────────────────────┘
+                              │
+       ┌──────────────────────┼───────────────────────┐
+       ▼                      ▼                       ▼
+  --version/-V?         #[cfg(release+mac)]      (other targets)
+       │                   relaunch block             │
+       │              ┌──────────────────┐            │
+       │              │ already_launched │            │
+       │              │ stdin is pipe?   │            │
+       │              └──────────────────┘            │
+       │                   │ no                       │
+       │                   ▼                          │
+       │     ┌─────────────────────────────────┐      │
+       │     │ extract_app_path(exe_str)       │      │
+       │     │   uses rfind(".app/")           │      │
+       │     └─────────────────────────────────┘      │
+       │                   │ Some(path)               │
+       │                   ▼                          │
+       │     ┌─────────────────────────────────┐      │
+       │     │ canonicalize + is_dir + ends    │      │
+       │     │ with ".app"?                    │      │
+       │     └─────────────────────────────────┘      │
+       │              │              │                │
+       │              │ ok           │ fail           │
+       │              ▼              ▼                │
+       │      Command::new("open")  warn + fall-through
+       │              .spawn()      │                 │
+       │              │             │                 │
+       │       ┌──────┴──────┐      │                 │
+       │       │ Ok          │ Err  │                 │
+       │       │             ▼      │                 │
+       │       │   eprintln!(err)+ fall-through       │
+       │       │             │      │                 │
+       │       ▼             ▼      ▼                 ▼
+       │   return     ─────────────────────► kusa_lib::run()
+       │
+       └──────► println!("kusa <ver>"); return;
+```
+
+## Component Design
+
+### Component: `extract_app_path` (new pure helper)
+
+- **Purpose**: Given the path string of the current executable, return the prefix that names the owning `.app` bundle, using a trailing-match strategy.
+- **Location**: `src-tauri/src/main.rs` (new free function near `main`, marked `#[cfg(all(not(debug_assertions), target_os = "macos"))]` or compiled unconditionally to keep tests runnable on all platforms — see Testing Strategy below for the chosen variant).
+- **Dependencies**: `std::str` only.
+- **Interface**:
+  ```rust
+  fn extract_app_path(exe_str: &str) -> Option<&str>;
+  ```
+- **Rationale for pure-helper extraction**: Issue #68 specifies that the new logic must be testable. Pulling the substring math into a free function lets us write `#[test]` cases without spawning a process or relying on a real `.app` bundle on disk.
+
+### Component: relaunch block in `main()` (rewrite of lines 79-85, with the line-41 fix)
+
+- **Purpose**: Best-effort detach-relaunch via `open -a`; never silently fails.
+- **Location**: `src-tauri/src/main.rs`, inside `#[cfg(all(not(debug_assertions), target_os = "macos"))]`.
+- **Dependencies**: `std::env`, `std::process::Command`, `std::path::Path`, `std::fs::canonicalize`, the existing `extract_app_path` helper.
+- **Interface**: Internal — no public surface change.
+- **Behavior outline (pseudo-code, not implementation)**:
+  ```text
+  let Ok(exe) = current_exe() else { goto fallback };
+  let exe_str = exe.to_string_lossy();
+  let Some(candidate) = extract_app_path(&exe_str) else { goto fallback };
+
+  // FR-006: verify it really is a .app bundle on disk
+  let Ok(canonical) = fs::canonicalize(candidate) else {
+      eprintln!("kusa: candidate bundle path '{candidate}' is not accessible; falling back");
+      goto fallback;
+  };
+  if !canonical.is_dir()
+     || canonical.extension().and_then(|s| s.to_str()) != Some("app")
+  {
+      eprintln!("kusa: candidate bundle path '{}' is not a .app bundle; falling back",
+                canonical.display());
+      goto fallback;
+  }
+
+  let resolved_args = resolve_user_args(...);  // existing logic, unchanged
+
+  let mut cmd = Command::new("open");
+  cmd.arg("-a").arg(&canonical).arg("--args").arg("--launched").args(&resolved_args);
+  match cmd.spawn() {
+      Ok(_) => return,
+      Err(e) => {
+          eprintln!("kusa: failed to relaunch via `open -a {}`: {e}", canonical.display());
+          eprintln!("kusa: falling back to in-process launch (CLI process will not detach)");
+          // fall through to kusa_lib::run()
+      }
+  }
+  // fallback:  (single label conceptually; in Rust, structure the function so control
+  // naturally reaches kusa_lib::run() at the bottom of main())
+  ```
+
+## API Contracts
+
+### `fn extract_app_path(exe_str: &str) -> Option<&str>`
+
+- **Signature**: `fn extract_app_path(exe_str: &str) -> Option<&str>`
+- **Input**:
+  - `exe_str`: the executable path as a `&str`, typically obtained from `std::env::current_exe().to_string_lossy()`.
+- **Output**:
+  - `Some(prefix)` where `prefix` is the substring of `exe_str` from index 0 through the **last** occurrence of `".app/"` plus 4 (i.e. including the trailing `.app` but excluding the `/`).
+  - `None` if `exe_str` does not contain `".app/"`.
+- **Errors**: None. Pure function.
+- **Examples** (illustrative; the unit tests in NFR-021 are the source of truth):
+  - `"/Applications/kusa.app/Contents/MacOS/kusa"` → `Some("/Applications/kusa.app")`
+  - `"/Applications/Outer.app/Contents/Frameworks/Inner.app/Contents/MacOS/kusa"` → `Some("/Applications/Outer.app/Contents/Frameworks/Inner.app")`
+  - `"/usr/local/bin/kusa"` → `None`
+  - `"/some/path.app/"` → `Some("/some/path.app")` (degenerate but well-defined: rfind matches, slice is `[..idx+4]`)
+
+### Stderr message contracts
+
+All messages are single-line, `kusa:` prefixed, terminated by `\n`. Format strings (exact):
+
+- Spawn failure (FR-010):
+  `kusa: failed to relaunch via \`open -a {app_path}\`: {error}`
+- Fallback notice (FR-011):
+  `kusa: falling back to in-process launch (CLI process will not detach)`
+- Invalid bundle (FR-012):
+  `kusa: candidate bundle path '{path}' is not a .app bundle; falling back to in-process launch`
+- Canonicalize failure (subset of FR-012):
+  `kusa: candidate bundle path '{path}' is not accessible ({error}); falling back to in-process launch`
+
+## Data Models
+
+This change introduces no new persistent data models. Transient values used in the relaunch block:
+
+| Name | Type | Source | Notes |
+|------|------|--------|-------|
+| `exe` | `std::path::PathBuf` | `std::env::current_exe()` | Already used in current code. |
+| `exe_str` | `String` | `exe.to_string_lossy().to_string()` | Already used. |
+| `candidate` | `&str` | `extract_app_path(&exe_str)` | New. Borrowed slice into `exe_str`. |
+| `canonical` | `std::path::PathBuf` | `std::fs::canonicalize(candidate)` | New. Validated bundle path. |
+| `resolved_args` | `Vec<String>` | Existing args-resolution logic, unchanged | No change. |
+
+## State Management
+
+No state outside the stack frame of `main()`. The fix is straight-line procedural code.
+
+## Error Handling Strategy
+
+The fix follows a "best-effort detach, guaranteed window" strategy:
+
+| Error point | Strategy | User-facing surface |
+|-------------|----------|----------------------|
+| `current_exe()` returns `Err` | Fall through to `kusa_lib::run()` silently | None (matches current behavior) |
+| `extract_app_path` returns `None` | Fall through silently | None (e.g. running from `cargo run` test build — already legal) |
+| `canonicalize` returns `Err` | Print FR-012 message, fall through | stderr line |
+| `canonical` not a `.app` directory | Print FR-012 message, fall through | stderr line |
+| `Command::spawn()` returns `Err` | Print FR-010 + FR-011 lines, fall through | 2 stderr lines |
+| `kusa_lib::run()` itself fails | Out of scope for this fix — existing app-level handling | n/a |
+
+Recovery in every case is the same: call `kusa_lib::run()`. The user sees a window. The terminal occupancy trade-off (no detach when fallback fires) is explicitly accepted per Issue #68.
+
+## Testing Strategy
+
+### Unit tests (added in this PR)
+
+Implemented in `src-tauri/src/main.rs` under `#[cfg(test)] mod tests`. Because the relaunch block itself is gated on `#[cfg(all(not(debug_assertions), target_os = "macos"))]` and `cargo test` runs in debug mode by default, the **helper `extract_app_path` must be available unconditionally** (not behind `#[cfg]`) so the tests run on all platforms in CI. The helper has no platform-specific dependencies, so this is safe.
+
+Test cases (NFR-021):
+
+1. `extract_app_path_single_bundle` — `"/Applications/kusa.app/Contents/MacOS/kusa"` → `Some("/Applications/kusa.app")`
+2. `extract_app_path_nested_bundles` — `"/Outer.app/Frameworks/Inner.app/Contents/MacOS/kusa"` → `Some("/Outer.app/Frameworks/Inner.app")`
+3. `extract_app_path_no_bundle` — `"/usr/local/bin/kusa"` → `None`
+4. `extract_app_path_trailing_slash` — `"/path/foo.app/"` → `Some("/path/foo.app")`
+5. `extract_app_path_empty_string` — `""` → `None`
+6. `extract_app_path_app_in_middle_only` — `"/path/foo.app.backup/kusa"` → `None` (no `".app/"` substring; the dot-suffix `.app.backup` must not match)
+
+### Integration / manual verification (out of unit scope, documented for the implementer)
+
+- AC-1: Build a release binary, rename the bundle to break the canonicalize step (e.g. move it to a temp dir then point a copy of the executable elsewhere), invoke from terminal, observe stderr + window opens.
+- AC-2: Replace `/usr/bin/open` PATH with a stub returning non-zero / removing exec permission in a sandbox, invoke, observe failure message + window opens. (Difficult to script in CI; performed by reviewer if practical.)
+- AC-4: Normal install path via Homebrew tap, invoke `kusa README.md`, observe CLI returns immediately and window opens.
+- AC-7: `kusa --version` still prints the version and returns, both in debug and release.
+
+### Lint / build
+
+- `cargo fmt --check` on `src-tauri/`
+- `cargo clippy -- -D warnings` on `src-tauri/`
+- `cargo build --release` on macOS
+- `cargo test` on macOS (and on Linux CI for the pure-helper tests)
+
+## Security Considerations
+
+- The fix narrows trust on the path used in `open -a`: previously any string ending in `.app/` from `find` was accepted; now the path must canonicalize and resolve to a real directory whose extension is `.app`. This is a strict improvement.
+- No new attack surface introduced. `kusa_lib::run()` is the same code path debug builds already use.
+- No new dependencies, so no new supply-chain exposure.
+
+## Implementation Notes (constraints reminder)
+
+- Single-file change: `src-tauri/src/main.rs`. No new crates, no other source modifications.
+- Preserve all existing comments unless they become factually wrong; update the block-comment at line 14-18 to mention the fallback if substantive.
+- Use `eprintln!` (not `println!`) — these are diagnostic messages, not stdout output.
+- Do **not** introduce `Box<dyn Error>`, `anyhow`, `thiserror`, etc. The existing code uses plain `std`; stay consistent.
+- Do **not** add `unwrap()` / `expect()` anywhere in the relaunch block. FR-031 forbids it.
+- Conventional Commits: implementation commit should be `fix(cli): handle relaunch spawn failure and use rfind for app path` (or similar).
+
+## Requirements Traceability
+
+| Requirement | Design element |
+|-------------|----------------|
+| FR-001 | relaunch block — `Command::new("open").arg("-a").arg(&canonical)...` |
+| FR-002 | `match spawn { Ok(_) => return, ... }` |
+| FR-003 | `match spawn { ..., Err(e) => { eprintln!; fall through } }` |
+| FR-004 | Preserved `#[cfg(all(not(debug_assertions), target_os = "macos"))]` gate |
+| FR-005 | `extract_app_path` uses `exe_str.rfind(".app/")` |
+| FR-006 | canonicalize + is_dir + extension == "app" guard |
+| FR-010 | Stderr message format "kusa: failed to relaunch via `open -a {app_path}`: {error}" |
+| FR-011 | Stderr message "kusa: falling back to in-process launch (CLI process will not detach)" |
+| FR-012 | Stderr message "kusa: candidate bundle path '{path}' is not a .app bundle; falling back ..." |
+| FR-020 | `if let Ok(exe) = current_exe()` — Err arm falls through (existing) |
+| FR-021 | `extract_app_path` returns `None` → fall through silently |
+| FR-022 | `already_launched` guard preserved as-is |
+| FR-023 | `stdin_is_pipe` guard preserved as-is |
+| FR-024 | `rfind(".app/")` selects last occurrence |
+| FR-030 | All `Result`s in the block are `match`ed or `if let`; no panics introduced |
+| FR-031 | No `.unwrap()` / `.expect()` on `spawn`/`canonicalize` |
+| NFR-001 | Single `canonicalize` call; reuse result for `is_dir` / `extension` |
+| NFR-002 | No threads/async/sleep added |
+| NFR-010 | Fallback always calls `kusa_lib::run()` |
+| NFR-011 | `--launched` flag passed to relaunch unchanged; fallback uses the same code as debug builds |
+| NFR-020 | `extract_app_path` as `fn(&str) -> Option<&str>` |
+| NFR-021 | Six unit tests enumerated in Testing Strategy |
+| NFR-030 | Only `src-tauri/src/main.rs` changes; no Cargo.toml changes |
+| NFR-031 | All stderr lines start with `kusa: ` |
+| NFR-040 | `#[cfg(...)]` gate preserved |
+| NFR-041 | Same — Linux/Windows are not compiled |
+| NFR-042 | `--version` block at top of `main()` untouched |
+
+## Open Questions
+
+None.

--- a/.kiro/specs/fix-cli-relaunch-spawn/requirements-init.md
+++ b/.kiro/specs/fix-cli-relaunch-spawn/requirements-init.md
@@ -1,0 +1,65 @@
+# Feature: fix-cli-relaunch-spawn
+
+## Overview
+
+CLI から `kusa <file>` で起動したときに、macOS の `open -a` による relaunch が失敗した場合でもユーザーに通知し、in-process fallback で必ず起動するようにする。
+あわせて、`exe_str.find(".app/")` による先頭マッチが原因で「実行ファイルとは別の `.app/` バンドル」が誤検出され spawn が失敗する経路を塞ぐ (rfind + canonicalize)。
+
+このバグは GitHub Issue #68 で報告されている。
+
+## Product Context
+
+kusa は AI 開発者のためのターミナルネイティブな Markdown エディター/ビューワーである。
+**Instant Open** がコアコンセプトの 1 つであり、CLI 引数 (`kusa file.md` / `kusa .`) から即座にウィンドウが出ることが体験の根幹を支えている。
+relaunch がサイレントに失敗してウィンドウが出ない現状は、このコアコンセプトに直接反する critical な体験劣化である。
+
+ターゲットユーザー: Claude Code, Cursor CLI, Kiro CLI などを使う AI 時代の開発者。彼らは "ターミナルから何かを叩く → 結果が出る" という即時性に強く依存している。
+
+## Initial Requirements
+
+### Functional Requirements
+
+- **FR-001 (Event-driven)**: When `kusa <file>` is invoked on macOS release builds and the relaunch via `open -a` fails to spawn, the system shall print a human-readable error message to stderr that includes the failed `app_path` and the underlying OS error.
+- **FR-002 (Event-driven)**: When the relaunch spawn fails, the system shall fall back to in-process execution by calling `kusa_lib::run()` so that a window is always shown.
+- **FR-003 (Event-driven)**: When extracting the `.app/` bundle path from the current executable path, the system shall use a trailing-match strategy (`rfind(".app/")`) so that nested or duplicated `.app/` substrings (e.g. `/Applications/Foo.app/Contents/Frameworks/Bar.app/...`) do not produce an incorrect path.
+- **FR-004 (Event-driven)**: When the extracted `app_path` does not exist on the filesystem or cannot be canonicalized to a directory, the system shall skip the `open -a` relaunch and fall back to in-process execution.
+- **FR-005 (Ubiquitous)**: The relaunch code path shall remain a no-op on debug builds and on non-macOS targets (preserve the existing `#[cfg(all(not(debug_assertions), target_os = "macos"))]` gate).
+- **FR-006 (Event-driven)**: When the relaunch spawn succeeds, the system shall return from `main()` immediately (preserve current behavior; the CLI process detaches).
+
+### Non-Functional Requirements
+
+- **NFR-001 (Ubiquitous)**: The `.app/` path extraction helper shall be implemented as a pure function so that it can be exercised by Rust unit tests without spawning a process.
+- **NFR-002 (Ubiquitous)**: The fix shall not regress the existing infinite-relaunch-loop prevention (`--launched` flag) nor the piped-stdin detach behavior.
+- **NFR-003 (Ubiquitous)**: The fix shall keep the Rust-side footprint minimal (project rule: "Rust 側は最小限") — no new crate dependencies and no architectural changes outside `src-tauri/src/main.rs`.
+- **NFR-004 (Ubiquitous)**: Error messages shall be prefixed with `kusa:` to make them easy to grep from terminal output.
+
+### Constraints
+
+- macOS リリースビルドのみが対象 (`#[cfg(all(not(debug_assertions), target_os = "macos"))]`)。debug build は relaunch ブロック自体スキップなので影響なし。
+- fallback で in-process 起動した場合、CLI プロセスは detach しない (ターミナルが占有される) が、ウィンドウが出ないより遥かに望ましい — これは明示的な受容トレードオフ。
+- 変更ファイルは原則 `src-tauri/src/main.rs` 1 つに限定 (他ファイルを触る必要があるのはテスト追加でビルドターゲット構成が必要な場合のみ)。
+- `git commit --no-verify` 禁止。
+
+### Assumptions
+
+- `.app/` バンドル path の抽出ロジックを pure helper として切り出せば Rust 単体テストでカバーできる。
+- spawn 失敗そのものの単体テストは macOS 環境依存が強く現実的でないため、helper レベルでのテストと、コードレビューでの目視確認に留める。
+- `kusa_lib::run()` を fallback で呼んでも既存のフローは破壊しない (現状の debug build と同じ経路を通るだけ)。
+
+### Open Questions
+
+- None — Issue #68 が修正方針まで明示しており、上記要件はその内容に沿って導出済み。
+
+## Pre-canned Q&A Record
+
+スペック初期化時に確認された 4 つの質問とその回答:
+
+1. **What is the feature's purpose?** → 「CLI から `kusa <file>` で起動したときに、macOS の `open -a` による relaunch が失敗した場合でもユーザーに通知し、in-process fallback で必ず起動するようにする。」
+2. **Who are the target users?** → 「terminal から kusa を起動するすべてのユーザー (Claude Code, Cursor CLI, Kiro CLI 等を使う AI 時代の開発者)」
+3. **What problem does it solve?** → 「`open -a` の spawn 失敗が握りつぶされ、ウィンドウが出ないまま CLI プロセスだけ return してしまう。ユーザーには何も通知されず、再現条件が不明確で苦痛。」
+4. **Are there any known constraints?** → 「macOS リリースビルドのみが対象。debug build は relaunch ブロック自体スキップなので影響なし。fallback で in-process 起動した場合、CLI プロセスは detach しない (ターミナルが占有される) が、ウィンドウが出ないより遥かに望ましい。」
+
+## Related
+
+- GitHub Issue: #68
+- Affected file: `src-tauri/src/main.rs` (lines 41-42 と 79-85)

--- a/.kiro/specs/fix-cli-relaunch-spawn/requirements.md
+++ b/.kiro/specs/fix-cli-relaunch-spawn/requirements.md
@@ -1,0 +1,101 @@
+# Requirements: fix-cli-relaunch-spawn
+
+## Document Info
+
+- Feature: fix-cli-relaunch-spawn
+- Status: Draft
+- Created: 2026-05-27
+- Linked Issue: #68
+
+## Overview
+
+macOS リリースビルドの `kusa <file>` 起動時、`open -a` による relaunch が失敗すると現状は spawn 結果が捨てられ、ウィンドウが出ないまま CLI プロセスだけが return してしまう。
+本機能はこのサイレント失敗を解消する。
+具体的には、(a) spawn 失敗をユーザーに通知し、(b) in-process fallback で必ずウィンドウを開き、(c) `.app/` バンドル path 抽出を `rfind` ベースに変更したうえで実在性を検証する。
+
+## Functional Requirements
+
+### Core Behavior
+
+- **FR-001 (Event-driven)**: When `kusa` is invoked on a macOS release build with `--launched` absent and stdin is not a pipe, the system shall attempt to relaunch the application bundle via `open -a <app_path> --args --launched <user_args>`.
+- **FR-002 (Event-driven)**: When the relaunch is attempted and `Command::spawn()` returns `Ok`, the system shall return from `main()` immediately so that the CLI process detaches.
+- **FR-003 (Event-driven)**: When the relaunch is attempted and `Command::spawn()` returns `Err(e)`, the system shall fall through to in-process execution by calling `kusa_lib::run()` instead of returning silently.
+- **FR-004 (Ubiquitous)**: The relaunch code path shall remain compiled out for non-macOS targets and for debug builds, by preserving the `#[cfg(all(not(debug_assertions), target_os = "macos"))]` gate.
+- **FR-005 (Event-driven)**: When extracting the application bundle path from the current executable path string, the system shall locate the substring `".app/"` using a trailing-match strategy (i.e. last occurrence) so that nested or duplicated `.app/` substrings do not cause an incorrect prefix to be selected.
+- **FR-006 (Event-driven)**: When the extracted candidate bundle path does not exist on the filesystem, or cannot be canonicalized to a directory ending in `.app`, the system shall skip the `open -a` relaunch and fall through to in-process execution.
+
+### User Interactions (CLI / stderr surface)
+
+- **FR-010 (Event-driven)**: When `Command::spawn()` fails, the system shall print a single human-readable error line to stderr that contains the prefix `kusa:`, the verb `failed to relaunch`, the attempted `app_path`, and the underlying `std::io::Error` display.
+- **FR-011 (Event-driven)**: When the system falls back to in-process execution after spawn failure, it shall print a second `kusa:`-prefixed informational line to stderr stating that the fallback path is being taken and warning that the CLI process will not detach.
+- **FR-012 (Event-driven)**: When the candidate bundle path validation fails (FR-006), the system shall print a `kusa:`-prefixed warning line to stderr identifying the invalid path before falling through, so that the failure mode is debuggable.
+
+### Edge Cases
+
+- **FR-020 (Event-driven)**: When `std::env::current_exe()` returns `Err`, the system shall not attempt to extract a bundle path and shall fall through to in-process execution. (Preserves current behavior.)
+- **FR-021 (Event-driven)**: When the current executable path does not contain `".app/"` at all, the system shall fall through to in-process execution without producing an error message. (Preserves current behavior — typical for developer test builds invoked directly.)
+- **FR-022 (Event-driven)**: When `args.iter().any(|a| a == "--launched")` is true, the system shall not enter the relaunch block and shall proceed to `kusa_lib::run()`. (Preserves the existing infinite-relaunch-loop guard.)
+- **FR-023 (Event-driven)**: When stdin is a pipe (`S_IFIFO`), the system shall not enter the relaunch block and shall proceed to `kusa_lib::run()`. (Preserves the existing piped-stdin behavior.)
+- **FR-024 (Event-driven)**: When the executable path contains multiple `.app/` substrings (e.g. `/Applications/Foo.app/Contents/Frameworks/Bar.app/Contents/MacOS/kusa`), the system shall select the prefix terminating at the **last** `.app/` so that the spawn target is the inner-most bundle that owns the running binary.
+
+### Error Handling
+
+- **FR-030 (Event-driven)**: If any step inside the relaunch block panics or returns an unrecoverable error not otherwise specified, the system shall not crash the CLI process; instead, control shall fall through to `kusa_lib::run()`. (Implemented by structuring the relaunch as a best-effort path with explicit fallback, not by `unwrap()`.)
+- **FR-031 (Ubiquitous)**: The system shall not use `.unwrap()` or `.expect()` on the `Command::spawn()` Result or on the `canonicalize`/`metadata` Result inside the relaunch block.
+
+## Non-Functional Requirements
+
+### Performance
+
+- **NFR-001 (Ubiquitous)**: The additional path-validation work (existence check + canonicalize) shall add no more than 1 stat-class syscall on the success path. (i.e. do not stat the bundle multiple times; reuse the canonicalize result.)
+- **NFR-002 (Ubiquitous)**: The fix shall not add new thread spawns, async runtimes, or sleeps to the cold-start hot path.
+
+### Reliability
+
+- **NFR-010 (Ubiquitous)**: The window-open success rate from `kusa <file>` invocations shall be 100% under all conditions where the in-process `kusa_lib::run()` itself can launch (i.e. spawn failure must never result in "no window").
+- **NFR-011 (Ubiquitous)**: The fallback path shall not introduce an infinite loop. (The `--launched` guard is unchanged; the in-process fallback does not re-enter the relaunch block.)
+
+### Testability
+
+- **NFR-020 (Ubiquitous)**: The `.app/` bundle path extraction logic shall be implemented as a pure function with signature compatible with `fn extract_app_path(exe_str: &str) -> Option<&str>` (or `Option<String>`), so it can be exercised by `#[test]` cases without spawning a process or touching the filesystem.
+- **NFR-021 (Ubiquitous)**: Unit tests shall cover at minimum: (i) single `.app/` in path, (ii) multiple `.app/` (rfind behavior), (iii) no `.app/` (None), (iv) `.app/` at end of path with no trailing component.
+
+### Maintainability
+
+- **NFR-030 (Ubiquitous)**: The fix shall be contained in `src-tauri/src/main.rs` only. No new files, no new crate dependencies, no API surface changes.
+- **NFR-031 (Ubiquitous)**: All stderr messages shall be prefixed with the literal `kusa:` so they are grep-able from terminal output.
+
+### Compatibility
+
+- **NFR-040 (Ubiquitous)**: The fix shall not change behavior of debug builds on macOS.
+- **NFR-041 (Ubiquitous)**: The fix shall not change behavior on Linux or Windows targets.
+- **NFR-042 (Ubiquitous)**: The fix shall not change the `--version` / `-V` short-circuit at the top of `main()`.
+
+## Acceptance Criteria
+
+1. **AC-1**: On a release build of macOS, invoking `kusa <file>` where the `.app/` path extraction picks a non-existent path causes a `kusa:`-prefixed message on stderr and the application window opens via the in-process fallback.
+2. **AC-2**: On a release build of macOS, if `Command::spawn()` returns `Err` for any reason, the user sees both the failure and fallback messages on stderr, and the application window opens.
+3. **AC-3**: When the executable lives inside a nested `.app/` (e.g. `Outer.app/.../Inner.app/Contents/MacOS/kusa`), `extract_app_path` returns the **inner** `.app/` prefix (the one that ends with the trailing `.app`).
+4. **AC-4**: Existing relaunch-success path is unchanged: when `open -a` succeeds, the CLI process returns immediately and the spawned process opens the window.
+5. **AC-5**: `cargo test -p kusa` (or equivalent) executes the new `extract_app_path` unit tests and they all pass on macOS, Linux, and Windows CI.
+6. **AC-6**: `cargo build --release` succeeds on macOS without new warnings (clippy clean for the touched file).
+7. **AC-7**: The `--launched` infinite-loop guard, the piped-stdin guard, and the `--version` short-circuit are all preserved as-is.
+
+## Traceability
+
+| requirements-init item | Expanded requirements |
+|------------------------|------------------------|
+| FR-001 (notify on spawn failure) | FR-010, FR-011 |
+| FR-002 (fall back to in-process) | FR-003, FR-030, FR-031 |
+| FR-003 (use rfind for trailing `.app/`) | FR-005, FR-024, NFR-020, NFR-021 |
+| FR-004 (validate canonicalize app_path) | FR-006, FR-012, NFR-001 |
+| FR-005 (preserve cfg gate) | FR-004, NFR-040, NFR-041 |
+| FR-006 (preserve detach on success) | FR-002, AC-4 |
+| NFR-001 (pure helper for testability) | NFR-020, NFR-021 |
+| NFR-002 (no regression of guards) | FR-022, FR-023, NFR-011, AC-7 |
+| NFR-003 (Rust footprint minimal) | NFR-030 |
+| NFR-004 (`kusa:` prefix) | FR-010, FR-011, FR-012, NFR-031 |
+
+## Open Questions
+
+None — Issue #68 specifies the fix in full and all initial requirements have been expanded above.

--- a/.kiro/specs/fix-cli-relaunch-spawn/spec.json
+++ b/.kiro/specs/fix-cli-relaunch-spawn/spec.json
@@ -1,0 +1,23 @@
+{
+  "feature_name": "fix-cli-relaunch-spawn",
+  "created_at": "2026-05-27T11:01:00+09:00",
+  "updated_at": "2026-05-27T11:01:00+09:00",
+  "language": "ja",
+  "phase": "tasks-generated",
+  "approvals": {
+    "requirements": {
+      "generated": true,
+      "approved": true
+    },
+    "design": {
+      "generated": true,
+      "approved": true
+    },
+    "tasks": {
+      "generated": true,
+      "approved": true
+    }
+  },
+  "ready_for_implementation": true,
+  "linked_issue": 68
+}

--- a/.kiro/specs/fix-cli-relaunch-spawn/tasks.md
+++ b/.kiro/specs/fix-cli-relaunch-spawn/tasks.md
@@ -1,0 +1,186 @@
+# Implementation Tasks: fix-cli-relaunch-spawn
+
+## Document Info
+
+- Feature: fix-cli-relaunch-spawn
+- Total tasks: 6
+- Parallelizable: 0 (all touch the same single file — strictly sequential)
+- Created: 2026-05-27
+- Auto-approved via `-y`
+- Linked Issue: #68
+- Requirements: ./requirements.md
+- Design: ./design.md
+
+## Scope Note
+
+All tasks modify the same file (`src-tauri/src/main.rs`). True file-level parallelism is therefore not possible. The tasks are sequenced so that each step is independently verifiable: a pure helper first (with tests), then call-site changes, then end-to-end build verification.
+
+## Task Dependency Graph
+
+```text
+T-001 (helper + tests)
+   │
+   ▼
+T-002 (use rfind via helper at call site)
+   │
+   ▼
+T-003 (canonicalize + bundle validation)
+   │
+   ▼
+T-004 (spawn match + fallback)
+   │
+   ▼
+T-005 (block-comment refresh)
+   │
+   ▼
+T-006 (build / clippy / test verification)
+```
+
+## Parallel Execution Groups
+
+None. All tasks are sequential (single-file feature).
+
+## Tasks
+
+### T-001: Add `extract_app_path` pure helper with unit tests
+
+- **Description**: Implement a pure free function `fn extract_app_path(exe_str: &str) -> Option<&str>` in `src-tauri/src/main.rs`. The function uses `exe_str.rfind(".app/")` and returns `Some(&exe_str[..idx + 4])` if found, else `None`. Add a `#[cfg(test)] mod tests` block in the same file with the 6 test cases enumerated in design.md Testing Strategy.
+- **Files**:
+  - Modify: `src-tauri/src/main.rs`
+- **Dependencies**: None
+- **Acceptance Criteria**:
+  - [ ] `extract_app_path` exists as a free function with the exact signature `fn extract_app_path(exe_str: &str) -> Option<&str>`.
+  - [ ] The function is compiled unconditionally (no `#[cfg]` gate) so it is testable on all platforms.
+  - [ ] All 6 unit tests pass: `extract_app_path_single_bundle`, `extract_app_path_nested_bundles`, `extract_app_path_no_bundle`, `extract_app_path_trailing_slash`, `extract_app_path_empty_string`, `extract_app_path_app_in_middle_only`.
+  - [ ] `cargo test -p kusa` passes locally (in the `src-tauri` workspace).
+- **Tests**: The 6 cases listed in design.md §Testing Strategy.
+- **Effort**: Small
+
+### T-002: Replace `exe_str.find(".app/")` with the helper at the call site
+
+- **Description**: In the relaunch block inside `main()` (currently around line 41), replace `if let Some(app_idx) = exe_str.find(".app/")` and the manual slice with a call to `extract_app_path(&exe_str)`. The control flow remains identical: `Some(candidate)` enters the relaunch attempt, `None` falls through to `kusa_lib::run()`.
+- **Files**:
+  - Modify: `src-tauri/src/main.rs`
+- **Dependencies**: T-001
+- **Acceptance Criteria**:
+  - [ ] `exe_str.find(".app/")` no longer appears in the file.
+  - [ ] `extract_app_path(&exe_str)` is the new source of `candidate`.
+  - [ ] Nested-bundle case yields the inner `.app` path (verified via T-001 tests).
+  - [ ] Existing `args` / `user_args` / `resolved_args` logic unchanged.
+- **Tests**: Covered by T-001.
+- **Effort**: Small
+
+### T-003: Validate `app_path` via canonicalize + is_dir + extension check
+
+- **Description**: After extracting `candidate`, call `std::fs::canonicalize(candidate)`. If it returns `Err`, print the FR-012 canonicalize-failure message to stderr and fall through to `kusa_lib::run()`. Otherwise check `canonical.is_dir() && canonical.extension().and_then(|s| s.to_str()) == Some("app")`; if either fails, print the FR-012 invalid-bundle message and fall through. Pass `&canonical` (not the raw `candidate`) to `Command::new("open").arg("-a")` so the validated path is what gets spawned. No `.unwrap()` / `.expect()` permitted on these `Result`s (FR-031).
+- **Files**:
+  - Modify: `src-tauri/src/main.rs`
+- **Dependencies**: T-002
+- **Acceptance Criteria**:
+  - [ ] `std::fs::canonicalize` is invoked exactly once on the candidate path.
+  - [ ] Canonicalize-Err path produces a `kusa:`-prefixed stderr line and falls through.
+  - [ ] is_dir/extension check produces a distinct `kusa:`-prefixed stderr line on failure and falls through.
+  - [ ] `Command::arg("-a")` receives the canonicalized path.
+  - [ ] No `.unwrap()` / `.expect()` introduced in this block.
+- **Tests**: Manual (AC-1). Unit-testing canonicalize behavior would require touching the filesystem; intentionally skipped.
+- **Effort**: Small
+
+### T-004: Match `Command::spawn()` and fall through on failure
+
+- **Description**: Replace `let _ = cmd.spawn(); return;` with `match cmd.spawn() { Ok(_) => return, Err(e) => { eprintln!(...failed...); eprintln!(...falling back...); /* fall through */ } }`. Ensure that when the `Err` arm executes, control reaches the existing `kusa_lib::run()` at the bottom of `main()` (i.e. do not early-return; do not nest inside another scope that ends with `return`).
+- **Files**:
+  - Modify: `src-tauri/src/main.rs`
+- **Dependencies**: T-003
+- **Acceptance Criteria**:
+  - [ ] `let _ = cmd.spawn();` no longer appears.
+  - [ ] `match cmd.spawn()` exists with `Ok(_) => return` and `Err(e) => { eprintln! ... }`.
+  - [ ] On `Err`, control reaches `kusa_lib::run()`.
+  - [ ] Both `eprintln!` lines use `kusa:` prefix and match the FR-010/FR-011 wording.
+- **Tests**: Manual (AC-2). Spawn-failure cannot be reliably injected in a unit test.
+- **Effort**: Small
+
+### T-005: Refresh the block comment to mention fallback behavior
+
+- **Description**: Update the existing block comment at lines 14-18 of `main.rs` to add a sentence: "If `open -a` spawn fails (or the bundle path is invalid), kusa falls back to in-process launch and prints a diagnostic to stderr." Keep the comment terse; this is a maintenance step so the next reader understands the fallback exists.
+- **Files**:
+  - Modify: `src-tauri/src/main.rs`
+- **Dependencies**: T-004
+- **Acceptance Criteria**:
+  - [ ] Block comment mentions the fallback path and stderr diagnostics.
+  - [ ] Comment is at most 8 lines.
+- **Tests**: N/A.
+- **Effort**: Small
+
+### T-006: Build + lint + test verification
+
+- **Description**: Run the full local verification suite: `cargo fmt --check`, `cargo clippy --all-targets -- -D warnings`, `cargo build --release`, `cargo test -p kusa`. Fix any issues surfaced. This is the integration / smoke-test task.
+- **Files**:
+  - Modify: `src-tauri/src/main.rs` (only if lint/test fixes are needed)
+- **Dependencies**: T-005
+- **Acceptance Criteria**:
+  - [ ] `cargo fmt --check` passes in `src-tauri/`.
+  - [ ] `cargo clippy --all-targets -- -D warnings` passes in `src-tauri/`.
+  - [ ] `cargo build --release` succeeds in `src-tauri/`.
+  - [ ] `cargo test -p kusa` passes (including the new `extract_app_path` tests).
+- **Tests**: All tests added in T-001 must pass.
+- **Effort**: Small
+
+## File Conflict Matrix
+
+| Task  | Files                          | Conflicts With                         |
+|-------|--------------------------------|----------------------------------------|
+| T-001 | src-tauri/src/main.rs          | T-002, T-003, T-004, T-005, T-006      |
+| T-002 | src-tauri/src/main.rs          | T-001, T-003, T-004, T-005, T-006      |
+| T-003 | src-tauri/src/main.rs          | T-001, T-002, T-004, T-005, T-006      |
+| T-004 | src-tauri/src/main.rs          | T-001, T-002, T-003, T-005, T-006      |
+| T-005 | src-tauri/src/main.rs          | T-001, T-002, T-003, T-004, T-006      |
+| T-006 | src-tauri/src/main.rs (maybe)  | All others                             |
+
+(Single-file feature — every task touches `src-tauri/src/main.rs`. They are sequenced explicitly via the dependency chain above.)
+
+## Requirements Traceability
+
+| Requirement | Tasks |
+|-------------|-------|
+| FR-001      | T-003, T-004 |
+| FR-002      | T-004 |
+| FR-003      | T-004 |
+| FR-004      | T-002, T-003, T-004 (preserves existing `#[cfg]` gate) |
+| FR-005      | T-001, T-002 |
+| FR-006      | T-003 |
+| FR-010      | T-004 |
+| FR-011      | T-004 |
+| FR-012      | T-003 |
+| FR-020      | T-002 (preserves `current_exe()` Err arm) |
+| FR-021      | T-002 (preserves `None` fall-through) |
+| FR-022      | T-002, T-003, T-004 (preserve `--launched` guard) |
+| FR-023      | T-002, T-003, T-004 (preserve pipe-stdin guard) |
+| FR-024      | T-001, T-002 |
+| FR-030      | T-003, T-004 |
+| FR-031      | T-003, T-004 |
+| NFR-001     | T-003 |
+| NFR-002     | T-003, T-004 |
+| NFR-010     | T-003, T-004 |
+| NFR-011     | T-002, T-003, T-004 |
+| NFR-020     | T-001 |
+| NFR-021     | T-001 |
+| NFR-030     | All tasks |
+| NFR-031     | T-003, T-004 |
+| NFR-040     | T-002, T-003, T-004 (preserve `#[cfg]` gate) |
+| NFR-041     | Same |
+| NFR-042     | All tasks (do not touch `--version` block) |
+| AC-1        | T-003 + T-006 (build) |
+| AC-2        | T-004 + manual review |
+| AC-3        | T-001 |
+| AC-4        | T-006 (no regression) |
+| AC-5        | T-001, T-006 |
+| AC-6        | T-006 |
+| AC-7        | T-002, T-003, T-004 (preserve guards) |
+
+## Open Questions
+
+None.
+
+## Suggested Next Step
+
+`/kiro:ao-run fix-cli-relaunch-spawn` — autonomous implementation via the AO orchestrator under the `solo-full-auto` preset.

--- a/src-tauri/src/main.rs
+++ b/src-tauri/src/main.rs
@@ -1,6 +1,22 @@
 // Prevents additional console window on Windows in release, DO NOT REMOVE!!
 #![cfg_attr(not(debug_assertions), windows_subsystem = "windows")]
 
+/// Extract the owning `.app` bundle path from an executable path string.
+///
+/// Uses a trailing-match strategy (`rfind(".app/")`) so that when the executable
+/// lives inside a nested `.app/` bundle (e.g. an outer bundle that contains a
+/// nested helper bundle), the *inner* — i.e. directly-owning — bundle is selected.
+///
+/// Returns `Some(&exe_str[..idx + 4])` (i.e. the prefix including the trailing `.app`
+/// but excluding the `/`) when `".app/"` is found, otherwise `None`.
+///
+/// Gated on `cfg(test)` OR `cfg(all(not(debug_assertions), target_os = "macos"))` so
+/// the helper compiles wherever the relaunch block uses it, *and* whenever tests run.
+#[cfg(any(test, all(not(debug_assertions), target_os = "macos")))]
+fn extract_app_path(exe_str: &str) -> Option<&str> {
+    exe_str.rfind(".app/").map(|idx| &exe_str[..idx + 4])
+}
+
 fn main() {
     // Handle --version / -V before anything else (works in both debug and release)
     {
@@ -16,6 +32,9 @@ fn main() {
     //   - First invocation (from terminal): no flag → relaunch via `open -a` → return
     //   - Second invocation (via `open`): --launched present → skip relaunch → run app
     // Piped stdin (e.g. `cat file | kusa`) is NOT a terminal, so it runs directly.
+    // If the `open -a` spawn fails (or the bundle path is invalid / non-existent),
+    // kusa falls back to in-process launch and prints a `kusa:`-prefixed diagnostic
+    // to stderr — the window is always shown, even at the cost of CLI detach.
     #[cfg(all(not(debug_assertions), target_os = "macos"))]
     {
         let args: Vec<String> = std::env::args().collect();
@@ -36,55 +55,141 @@ fn main() {
         };
 
         if !already_launched && !stdin_is_pipe {
-            if let Ok(exe) = std::env::current_exe() {
+            'relaunch: {
+                let Ok(exe) = std::env::current_exe() else {
+                    break 'relaunch;
+                };
                 let exe_str = exe.to_string_lossy().to_string();
-                if let Some(app_idx) = exe_str.find(".app/") {
-                    let app_path = &exe_str[..app_idx + 4];
-                    // Collect user args (skip program name), exclude internal flags
-                    let user_args: Vec<String> = args
-                        .iter()
-                        .skip(1)
-                        .filter(|a| a.as_str() != "--launched")
-                        .cloned()
-                        .collect();
+                let Some(candidate) = extract_app_path(&exe_str) else {
+                    break 'relaunch;
+                };
 
-                    // Resolve relative file paths to absolute before relaunching.
-                    // `open -a` changes cwd, so relative paths must be resolved here.
-                    let cwd = std::env::current_dir().ok();
-                    let resolved_args: Vec<String> = user_args
-                        .iter()
-                        .map(|arg| {
-                            if !arg.starts_with('-') {
-                                let p = std::path::Path::new(arg);
-                                // Already absolute — just canonicalize if possible
-                                if p.is_absolute() {
-                                    return std::fs::canonicalize(p)
-                                        .map(|a| a.to_string_lossy().to_string())
-                                        .unwrap_or_else(|_| arg.clone());
-                                }
-                                // Relative path — resolve against cwd
-                                if let Some(ref cwd) = cwd {
-                                    let abs = cwd.join(p);
-                                    // Use canonicalize if the file exists, otherwise keep the joined path
-                                    return std::fs::canonicalize(&abs)
-                                        .unwrap_or(abs)
-                                        .to_string_lossy()
-                                        .to_string();
-                                }
+                // Validate the candidate bundle path before handing it to `open -a`.
+                // This prevents the historical silent failure where matching the
+                // wrong `.app/` substring caused `open -a` to be invoked with a path
+                // that did not exist, and `spawn()`'s `Err` was discarded.
+                let canonical = match std::fs::canonicalize(candidate) {
+                    Ok(p) => p,
+                    Err(e) => {
+                        eprintln!(
+                            "kusa: candidate bundle path '{}' is not accessible ({}); falling back to in-process launch",
+                            candidate, e
+                        );
+                        break 'relaunch;
+                    }
+                };
+                if !canonical.is_dir()
+                    || canonical.extension().and_then(|s| s.to_str()) != Some("app")
+                {
+                    eprintln!(
+                        "kusa: candidate bundle path '{}' is not a .app bundle; falling back to in-process launch",
+                        canonical.display()
+                    );
+                    break 'relaunch;
+                }
+
+                // Collect user args (skip program name), exclude internal flags
+                let user_args: Vec<String> = args
+                    .iter()
+                    .skip(1)
+                    .filter(|a| a.as_str() != "--launched")
+                    .cloned()
+                    .collect();
+
+                // Resolve relative file paths to absolute before relaunching.
+                // `open -a` changes cwd, so relative paths must be resolved here.
+                let cwd = std::env::current_dir().ok();
+                let resolved_args: Vec<String> = user_args
+                    .iter()
+                    .map(|arg| {
+                        if !arg.starts_with('-') {
+                            let p = std::path::Path::new(arg);
+                            // Already absolute — just canonicalize if possible
+                            if p.is_absolute() {
+                                return std::fs::canonicalize(p)
+                                    .map(|a| a.to_string_lossy().to_string())
+                                    .unwrap_or_else(|_| arg.clone());
                             }
-                            arg.clone()
-                        })
-                        .collect();
+                            // Relative path — resolve against cwd
+                            if let Some(ref cwd) = cwd {
+                                let abs = cwd.join(p);
+                                // Use canonicalize if the file exists, otherwise keep the joined path
+                                return std::fs::canonicalize(&abs)
+                                    .unwrap_or(abs)
+                                    .to_string_lossy()
+                                    .to_string();
+                            }
+                        }
+                        arg.clone()
+                    })
+                    .collect();
 
-                    let mut cmd = std::process::Command::new("open");
-                    cmd.arg("-a").arg(app_path).arg("--args");
-                    cmd.arg("--launched");
-                    cmd.args(&resolved_args);
-                    let _ = cmd.spawn();
-                    return;
+                let mut cmd = std::process::Command::new("open");
+                cmd.arg("-a").arg(&canonical).arg("--args");
+                cmd.arg("--launched");
+                cmd.args(&resolved_args);
+                match cmd.spawn() {
+                    Ok(_) => return,
+                    Err(e) => {
+                        eprintln!(
+                            "kusa: failed to relaunch via `open -a {}`: {}",
+                            canonical.display(),
+                            e
+                        );
+                        eprintln!(
+                            "kusa: falling back to in-process launch (CLI process will not detach)"
+                        );
+                        // Fall through to kusa_lib::run() below
+                    }
                 }
             }
         }
     }
     kusa_lib::run()
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn extract_app_path_single_bundle() {
+        assert_eq!(
+            extract_app_path("/Applications/kusa.app/Contents/MacOS/kusa"),
+            Some("/Applications/kusa.app")
+        );
+    }
+
+    #[test]
+    fn extract_app_path_nested_bundles() {
+        assert_eq!(
+            extract_app_path(
+                "/Applications/Outer.app/Contents/Frameworks/Inner.app/Contents/MacOS/kusa"
+            ),
+            Some("/Applications/Outer.app/Contents/Frameworks/Inner.app")
+        );
+    }
+
+    #[test]
+    fn extract_app_path_no_bundle() {
+        assert_eq!(extract_app_path("/usr/local/bin/kusa"), None);
+    }
+
+    #[test]
+    fn extract_app_path_trailing_slash() {
+        assert_eq!(extract_app_path("/path/foo.app/"), Some("/path/foo.app"));
+    }
+
+    #[test]
+    fn extract_app_path_empty_string() {
+        assert_eq!(extract_app_path(""), None);
+    }
+
+    #[test]
+    fn extract_app_path_app_in_middle_only() {
+        // `.app.backup/` does not contain the substring `.app/`, so the
+        // helper must return None — confirming that we match on the *exact*
+        // bundle separator, not a generic `.app` suffix.
+        assert_eq!(extract_app_path("/path/foo.app.backup/kusa"), None);
+    }
 }


### PR DESCRIPTION
Closes #68

## Summary

macOS release builds previously used `let _ = cmd.spawn()` for the `open -a` relaunch, which silently dropped any `Err`. Combined with `exe_str.find(".app/")` (which can match a sibling `.app/` substring earlier in the path), this produced a hang where the CLI process returned immediately but no window appeared and nothing was printed to stderr.

Three fixes, all confined to `src-tauri/src/main.rs`:

- **rfind-based extraction** — new `extract_app_path` helper uses `rfind(".app/")` so nested bundles (e.g. `Outer.app/Frameworks/Inner.app/...`) resolve to the **inner** — i.e. directly-owning — bundle.
- **Validated bundle path** — the candidate path is canonicalized and required to be a directory with `.app` extension before being passed to `open -a`. On failure, a `kusa:`-prefixed diagnostic is printed to stderr and control falls through to `kusa_lib::run()` (in-process fallback).
- **`match cmd.spawn()`** — on `Err`, two `kusa:`-prefixed stderr lines are printed (the failed invocation + the fallback notice) and control falls through to `kusa_lib::run()`.

Behavioral guarantee: the window is **always** shown when in-process `kusa_lib::run()` itself can launch — at the cost of CLI detach when the fallback path fires (terminal occupancy). This trade-off is explicitly accepted in the spec (`.kiro/specs/fix-cli-relaunch-spawn/`).

## Diagnostics emitted to stderr

| Failure mode | Message format |
|---|---|
| canonicalize failure | `kusa: candidate bundle path '<path>' is not accessible (<err>); falling back to in-process launch` |
| not a `.app` dir | `kusa: candidate bundle path '<path>' is not a .app bundle; falling back to in-process launch` |
| `Command::spawn()` failure | `kusa: failed to relaunch via \`open -a <path>\`: <err>` followed by `kusa: falling back to in-process launch (CLI process will not detach)` |

## Tests

Added 6 unit tests for `extract_app_path` in `#[cfg(test)] mod tests`:

- `extract_app_path_single_bundle` — `/Applications/kusa.app/Contents/MacOS/kusa` → `Some("/Applications/kusa.app")`
- `extract_app_path_nested_bundles` — outer/inner bundle picks **inner** (rfind behavior)
- `extract_app_path_no_bundle` — `/usr/local/bin/kusa` → `None`
- `extract_app_path_trailing_slash` — `/path/foo.app/` → `Some("/path/foo.app")`
- `extract_app_path_empty_string` — `""` → `None`
- `extract_app_path_app_in_middle_only` — `/path/foo.app.backup/kusa` → `None` (no `".app/"` substring)

`Command::spawn()` failure is intentionally not unit-tested (macOS-environment-dependent and hard to inject reliably); it is exercised by AC-2 manual verification per the spec.

## Verification

- `cargo test --bin kusa` — 6/6 passing
- `cargo clippy --bin kusa -- -D warnings` — clean (debug)
- `cargo clippy --bin kusa --release -- -D warnings` — clean (release)
- `cargo check --bin kusa --release` — clean
- `cargo fmt --check src/main.rs` — clean

## Out of scope

- Linux / Windows: no change (the relaunch block is gated on `target_os = "macos"`).
- Debug builds on macOS: no change (the relaunch block is gated on `not(debug_assertions)`).
- `--version` / `-V` short-circuit at the top of `main()`: untouched.
- The `--launched` infinite-loop guard, the piped-stdin guard, and the `cwd`-based relative-path resolution: untouched.

## Test plan

- [x] `cargo test --bin kusa` passes
- [x] `cargo clippy --bin kusa --release -- -D warnings` passes
- [x] `cargo check --bin kusa --release` passes
- [ ] (manual on reviewer's machine) Confirm `kusa --version` still works in both debug and release
- [ ] (manual on reviewer's machine) Confirm normal `kusa <file>` from terminal still detaches and opens the window

## Spec

The full SDD spec (requirements, design, tasks) is at `.kiro/specs/fix-cli-relaunch-spawn/` and is part of this PR (committed in the previous commit `docs(spec): add fix-cli-relaunch-spawn spec for issue #68`).

---

Generated via konbini `solo-full-auto` SDD pipeline.