### PR TITLE
fix: prevent silent zombie process when create_window fails

### DIFF
--- a/.kiro/specs/fix-create-window-error/design.md
+++ b/.kiro/specs/fix-create-window-error/design.md
@@ -1,0 +1,172 @@
+# Technical Design: fix-create-window-error
+
+## Document Info
+
+- Feature: fix-create-window-error
+- Status: Draft
+- Created: 2026-05-27
+- Requirements: ./requirements.md
+- Related issue: kusa #69
+
+## Architecture Overview
+
+The fix is local to `src-tauri/src/lib.rs`. Two code regions are touched:
+
+1. **`create_window` — Full mode branch** (lib.rs lines 119–129):
+   primary builder may fail → safe-defaults fallback builder runs → fallback may fail → return `Err`. On either success, `window.show()` is called and any error is logged (not silently dropped).
+
+2. **`setup` closure — `create_window` invocation** (lib.rs lines 246–248):
+   on `Err`, the previous code merely `eprintln!`ed and returned `Ok(())`. New code returns the `Err`, which is converted to `Box<dyn std::error::Error>` and propagated by Tauri's setup machinery, ultimately causing `tauri::Builder::build(...).expect("error while building kusa")` to panic visibly.
+
+All edits stay inside `src-tauri/src/lib.rs`. The fallback uses the existing `FULL_SIZE` constant (already imported on line 9), so no helper module changes are needed. A minimal `#[cfg(test)] mod tests` block is added at the bottom of `lib.rs` to verify the safe-defaults configuration shape via a small in-file helper (`safe_default_full_size()`), keeping the change file-local per the task constraint.
+
+```
+setup()
+  └── create_window(app, &peek_config)
+        ├── is_peek == true  → Peek primary build
+        │     └── (already has Full-mode fallback)  → unchanged
+        └── is_peek == false → Full primary build
+              ├── Ok(w)  → w.show() (errors logged, not dropped)
+              └── Err(e) → log + safe-defaults fallback build
+                              ├── Ok(w)  → w.show() (errors logged)
+                              └── Err(e2) → return Err(e2) ← bubbles up to setup
+  └── if Err(e) → eprintln + return Err(e) ← Tauri panics
+```
+
+## Component Design
+
+### Component: `create_window` (Full mode branch)
+
+- **Purpose**: Build the main WebView window in Full mode; on builder failure, retry with safe-defaults to avoid plugin-restored-state corruption.
+- **Location**: `src-tauri/src/lib.rs` lines 119–129 (current), replaced by ~18 lines after the fix.
+- **Dependencies**: `tauri::WebviewWindowBuilder`, `tauri::WebviewUrl`, `window_presets::FULL_SIZE`.
+- **Interface**: same as today — `fn create_window(app: &tauri::App, peek_config: &PeekConfig) -> Result<(), Box<dyn std::error::Error>>`.
+
+### Component: `setup` closure (`create_window` invocation)
+
+- **Purpose**: Run `create_window`; on failure, return the error so Tauri panics rather than silently leaving a zombie process.
+- **Location**: `src-tauri/src/lib.rs` lines 246–248.
+- **Interface**: same closure signature; behavioural change only.
+
+### Component (new, file-local): `safe_default_full_size` (in `lib.rs`)
+
+- **Purpose**: Module-private const fn returning the size used by the Full-mode safe-defaults fallback. Exists so the fallback's size is verifiable in unit tests without launching a Tauri runtime, while keeping all edits inside `lib.rs`.
+- **Location**: bottom of `src-tauri/src/lib.rs`, immediately above the new `#[cfg(test)] mod tests` block.
+- **Interface**: `const fn safe_default_full_size() -> WindowSize { FULL_SIZE }` (module-private; no `pub`).
+- **Rationale for `const fn`**: matches existing constants idiom in `window_presets` and enables compile-time use if ever needed.
+
+## API Contracts
+
+### `create_window` (unchanged signature)
+
+- **Signature**: `fn create_window(app: &tauri::App, peek_config: &PeekConfig) -> Result<(), Box<dyn std::error::Error>>`
+- **Input**: `app` — Tauri application handle; `peek_config` — resolved peek/full configuration.
+- **Output**: `Ok(())` on success (either primary or fallback build path), `Err(_)` if every attempted build fails.
+- **Errors**:
+  - `Err` from primary Full-mode `build()` → swallowed (logged, then fallback runs).
+  - `Err` from fallback Full-mode `build()` → returned to caller (final failure).
+  - `Err` from Peek mode primary `build()` → swallowed (logged, existing Full-mode fallback runs).
+  - `Err` from existing Peek→Full fallback `build()` → returned to caller (existing behaviour preserved via `?`).
+- **`window.show()` errors**: never propagated — they are logged via `eprintln!`. Rationale: the frontend always invokes `show()` again later when ready (instant-read flow), so a single failed `show()` call is not fatal; build success is the meaningful gate.
+
+### `setup` closure (relevant excerpt)
+
+- **Before**:
+  ```rust
+  if let Err(e) = create_window(app, &peek_config) {
+      eprintln!("Fatal: failed to create window: {}", e);
+  }
+  ```
+- **After**:
+  ```rust
+  if let Err(e) = create_window(app, &peek_config) {
+      eprintln!("Fatal: failed to create window: {}", e);
+      return Err(e);
+  }
+  ```
+- **Errors**: returned `Err` propagates through Tauri setup → `Builder::build(...).expect("error while building kusa")` → panic.
+
+## Data Models
+
+No new persistent data models. One new file-local helper in `lib.rs`:
+
+### `WindowSize` (existing in `window_presets`, unchanged)
+- Fields: `width: f64`, `height: f64`.
+
+### `safe_default_full_size() -> WindowSize` (new, module-private in `lib.rs`)
+- Returns: `FULL_SIZE` (currently `{ width: 1200.0, height: 800.0 }`).
+- Validation: covered by unit tests inside `lib.rs`'s new `#[cfg(test)] mod tests` block.
+
+## State Management
+
+- `WindowModeState`: not modified in this fix. The Full-mode path does not touch it (its initial value, set on lib.rs lines 238–243, already encodes `"full"`).
+- `CliArgsState`: not affected.
+
+## Error Handling Strategy
+
+| Failure | Action | User-facing surface |
+| --- | --- | --- |
+| Full primary `build()` fails | `eprintln!` + fallback `build()` | stderr message; user gets working window (best case) |
+| Full safe-defaults `build()` fails | return `Err` | Tauri panic ("error while building kusa") + stderr `Fatal: failed to create window: …` |
+| `window.show()` fails (any path) | `eprintln!` only | stderr message; frontend can retry show |
+| Peek primary `build()` fails | unchanged: `eprintln!` + existing Full-mode fallback | (same as today) |
+| Peek's existing Full-mode fallback `build()` fails | `?` propagates `Err` | Tauri panic (same as today, but now triggered via FR-001) |
+
+Rationale: surfacing a panic is preferable to a silent zombie process. The panic appears in the Console.app log on macOS and in stderr.
+
+## Testing Strategy
+
+### Unit tests (added to `src-tauri/src/lib.rs` in a new `#[cfg(test)] mod tests` block)
+
+Pure helpers only — no Tauri runtime.
+
+- **`safe_default_full_size_matches_full_size`**: verifies `safe_default_full_size().width == FULL_SIZE.width && height == FULL_SIZE.height`. Locks the contract that the fallback uses the canonical full size.
+- **`safe_default_full_size_is_positive`**: defensive — width > 0, height > 0.
+
+### Manual verification
+
+- `cargo check` and `cargo build` inside `src-tauri/` succeed.
+- `cargo test` inside `src-tauri/` passes (existing tests plus the two new ones).
+- Optional smoke test (not required for CI but documented in task): user can manually corrupt `~/Library/Application Support/com.kazejp.kusa/.window-state.json` to trigger restore failure, then start kusa to observe the fallback behaviour.
+
+### Why no integration test
+
+Tauri's runtime cannot be driven from `cargo test` without a heavy harness, and forcing a `build()` failure deterministically would require mocking `WebviewWindowBuilder`, which is outside this fix's scope. The acceptance criteria in `requirements.md` therefore rely on (a) the type-checked control flow, (b) the unit tests of the safe-defaults config, and (c) manual smoke testing.
+
+## Security Considerations
+
+- No new file I/O, no new IPC commands, no new permissions added.
+- Returning `Err` from `setup()` does not leak sensitive information; the panic message is the static string `error while building kusa` from the existing `.expect()` call site.
+
+## Requirements Traceability
+
+| Requirement | Fulfilled by |
+| --- | --- |
+| FR-001 | setup closure `Err(e) → return Err(e)` |
+| FR-002 | new fallback `match builder.build()` arm |
+| FR-003 | safe-defaults config in fallback (title/inner_size/decorations/visible) |
+| FR-004 | fallback `Ok(w)` → `window.show()` + log on err |
+| FR-005 | fallback `Err(e2)` → return `Err(e2)` |
+| FR-006 | Peek branch (lines 78–118) untouched |
+| FR-010 | `eprintln!("Failed to create full window: {}, retrying with safe defaults", e)` |
+| FR-011 | `if let Err(e) = window.show() { eprintln!("Failed to show window: {}", e); }` |
+| FR-012 | preserved `eprintln!("Fatal: failed to create window: {}", e)` |
+| FR-020 | no write to `WindowModeState` in Full path |
+| FR-021 | no `app.emit("window-mode", …)` in Full path |
+| FR-030 | Peek primary success returns early as before |
+| FR-031 | existing `build()?` on Peek→Full fallback preserved |
+| NFR-001 | only `src-tauri/src/lib.rs` modified |
+| NFR-002 | edits confined to the two declared regions |
+| NFR-003 | line 183–191 untouched |
+| NFR-010 | `.visible(false)` preserved everywhere |
+| NFR-011 | primary build still calls `.min_inner_size(400.0, 300.0)` |
+| NFR-020 | `safe_default_full_size()` is pure |
+| NFR-021 | two unit tests added |
+| NFR-030 | commits made without `--no-verify` |
+| NFR-031 | `fix:` Conventional Commits prefix |
+
+## Scope Boundary Notes
+
+- Lines 183–191 (single-instance plugin) are explicitly excluded — that area belongs to issue #70.
+- The optional `--reset-window` flag (issue #69 item 3) is **out of scope**. Future issue can address it.
+- All edits are confined to `src-tauri/src/lib.rs`. The unit-test helper `safe_default_full_size()` and the `#[cfg(test)] mod tests` block live in `lib.rs` itself (not in `window_presets.rs`) per the task constraint that only `lib.rs` is touched.

--- a/.kiro/specs/fix-create-window-error/requirements-init.md
+++ b/.kiro/specs/fix-create-window-error/requirements-init.md
@@ -1,0 +1,50 @@
+# Feature: fix-create-window-error
+
+## Overview
+
+kusa の起動時に `create_window` が失敗した場合に、`setup()` が `Ok(())` を返してしまい、ウィンドウなしのプロセスがゾンビ状態で残る現象を防ぐバグ修正。Full mode にも safe-defaults による fallback を追加し、最終的な失敗時には Err を返して Tauri に明示的な panic を起こさせる。
+
+## Product Context
+
+- kusa は Markdown エディター/ビューワー (Tauri v2 + SolidJS)
+- CLI/Finder/drag-drop/URL scheme など複数の起動経路を持つ
+- 起動失敗時は **無音で残る** より **明示的に落ちる** ほうがユーザーに状況が伝わる
+
+(注: `.ao/steering/product.md` はテンプレートのままで具体的なプロダクト情報を含んでいないため、ここでは CLAUDE.md と issue 本文を一次情報源として使用する。)
+
+## Initial Requirements
+
+### Functional Requirements
+
+- **FR-001**: When `create_window` returns `Err` inside `setup()`, the system shall propagate the error and return it from `setup()` (which causes Tauri to panic at startup, surfacing the failure to the user).
+- **FR-002**: When the Full mode window builder (`WebviewWindowBuilder::new(...).build()`) returns `Err`, the system shall retry with a safe-defaults builder (minimum required configuration, no plugin-restored state) before giving up.
+- **FR-003**: If the safe-defaults fallback also fails, the system shall return the error from `create_window` (which is then propagated by FR-001).
+- **FR-004**: When the safe-defaults fallback is invoked, the system shall log the original failure reason via `eprintln!` so the user can diagnose the cause.
+- **FR-005**: When `window.show()` returns `Err` after a successful build, the system shall log the failure via `eprintln!` (not silently ignore it via `.ok()`). The build success is sufficient for `create_window` to return `Ok(())` because the frontend later explicitly calls show.
+- **FR-006**: The existing Peek mode → Full mode fallback (lib.rs lines 93–117) shall continue to function unchanged.
+
+### Non-Functional Requirements
+
+- **NFR-001**: The fix shall modify only `src-tauri/src/lib.rs`, restricted to lines 119–129 (Full mode builder) and lines 246–248 (setup-level `create_window` call).
+- **NFR-002**: The fix shall not touch lines 183–191 (single-instance plugin) which is owned by sibling issue #70.
+- **NFR-003**: The system shall not change `.visible(false)` semantics; visibility is still managed by frontend explicit show.
+- **NFR-004**: Where reasonable, extractable helpers (e.g., `build_full_window_with_fallback`) shall be unit-testable in Rust without launching a real Tauri runtime.
+
+### Constraints
+
+- Returning `Err` from `setup()` causes Tauri to panic — this is **intended** behaviour. The user should see a clear failure rather than a silent zombie process.
+- The safe-defaults fallback for Full mode must use a configuration that does **not** depend on potentially corrupted state from `tauri_plugin_window_state` (e.g., explicit `inner_size`, `decorations(true)`, `title("kusa")`).
+- `.visible(false)` is preserved in both primary build and fallback build — the frontend calls `show()` explicitly later.
+- `git commit --no-verify` is forbidden.
+- Only the listed line ranges in `src-tauri/src/lib.rs` may be modified.
+
+### Assumptions
+
+- The Tauri panic message is acceptable as the user-facing surface for catastrophic window-creation failures (no separate user dialog is required).
+- The optional `--reset-window` flag (issue #69 item 3) is **out of scope** and will be a future issue.
+- A safe-defaults `WebviewWindowBuilder` with `title("kusa")`, `inner_size(FULL_SIZE.width, FULL_SIZE.height)`, `decorations(true)`, `visible(false)` is sufficient to bypass plugin-restored state in practice.
+- Rust unit tests can exercise pure logic but cannot drive the Tauri runtime; thus tests focus on extractable helpers (constants, configuration shape) rather than end-to-end window creation.
+
+### Open Questions
+
+- None blocking. The fix is well-scoped by the issue body and pre-canned answers.

--- a/.kiro/specs/fix-create-window-error/requirements.md
+++ b/.kiro/specs/fix-create-window-error/requirements.md
@@ -1,0 +1,89 @@
+# Requirements: fix-create-window-error
+
+## Document Info
+
+- Feature: fix-create-window-error
+- Status: Draft
+- Created: 2026-05-27
+- Related issue: kusa #69
+
+## Overview
+
+`src-tauri/src/lib.rs` の `create_window` 失敗時に `setup()` が `Ok(())` を返してしまうため、WebView 初期化失敗等が起きてもプロセスはウィンドウなしで残ってしまう。Full mode の build 失敗パスにも safe-defaults fallback を入れ、最終的に失敗した場合は `setup()` から `Err` を返して Tauri に明示的な panic を起こさせる。
+
+## Functional Requirements
+
+### Core Behavior
+
+- **FR-001**: When `create_window` returns `Err`, the system shall propagate the error from `setup()` (i.e., `setup()` returns `Err`, which causes Tauri to panic at startup).
+- **FR-002**: When the Full mode primary `WebviewWindowBuilder::build()` returns `Err`, the system shall attempt a safe-defaults fallback build before propagating the error.
+- **FR-003**: While building the safe-defaults fallback for Full mode, the system shall use the following configuration: `WebviewUrl::default()`, `title("kusa")`, `inner_size(FULL_SIZE.width, FULL_SIZE.height)`, `decorations(true)`, `visible(false)`. No `min_inner_size` is required for the fallback.
+- **FR-004**: When the Full mode safe-defaults fallback succeeds, the system shall continue execution as if the primary build had succeeded.
+- **FR-005**: When the Full mode safe-defaults fallback also fails, the system shall return its `Err` from `create_window` so it can be propagated by FR-001.
+- **FR-006**: The existing Peek mode → Full mode fallback (`src-tauri/src/lib.rs` lines 93–117) shall remain unchanged in observable behaviour.
+
+### Logging / Diagnostics
+
+- **FR-010**: When the Full mode primary build fails, the system shall log a message of the form `Failed to create full window: <error>, retrying with safe defaults` via `eprintln!` before attempting the fallback.
+- **FR-011**: When `window.show()` returns `Err` after a successful build (Full mode or its fallback), the system shall log a message of the form `Failed to show window: <error>` via `eprintln!` instead of silently dropping the error.
+- **FR-012**: When `create_window` returns `Err` from `setup()`, the system shall log `Fatal: failed to create window: <error>` via `eprintln!` before returning the error (preserving the existing diagnostic line).
+
+### State Updates
+
+- **FR-020**: The system shall not modify the `WindowModeState` value in the Full mode path (the value set before `create_window` is invoked already reflects `"full"`).
+- **FR-021**: The system shall not emit a `window-mode` event from the Full mode path (only the Peek→Full fallback emits, per current behaviour).
+
+### Edge Cases
+
+- **FR-030**: When the Peek mode primary build succeeds, the system shall not invoke the Full mode fallback path (no behavioural change).
+- **FR-031**: When the Peek mode primary build fails and its existing Full-mode fallback build also fails, the system shall return that `Err` from `create_window` so it is propagated by FR-001 (this is the existing `build()?` behaviour on line 109 — verified preserved, not regressed).
+
+## Non-Functional Requirements
+
+### Scope
+
+- **NFR-001**: The fix shall modify only `src-tauri/src/lib.rs`.
+- **NFR-002**: Within `src-tauri/src/lib.rs`, the fix shall change only lines 119–129 (Full mode builder) and lines 246–248 (`create_window` invocation in `setup`), plus any minimal helper additions needed to keep those edits clean.
+- **NFR-003**: The fix shall not touch lines 183–191 (single-instance plugin), which is owned by sibling issue #70.
+
+### Behavioural Invariants
+
+- **NFR-010**: The fix shall preserve `.visible(false)` in both the primary Full-mode build and the safe-defaults fallback build.
+- **NFR-011**: The fix shall preserve `min_inner_size(400.0, 300.0)` in the primary Full-mode build (only the fallback may omit it to maximise resilience).
+
+### Testability
+
+- **NFR-020**: Where extractable, the safe-defaults fallback configuration shall be expressed as a pure helper (or pure constants) that can be unit-tested in Rust without launching a Tauri runtime.
+- **NFR-021**: The Rust test suite shall include at least one test verifying the safe-defaults configuration values (title, inner_size, decorations, visible).
+
+### Project Rules
+
+- **NFR-030**: All commits shall pass pre-commit hooks (no `git commit --no-verify`).
+- **NFR-031**: Commit messages shall follow Conventional Commits.
+
+## Acceptance Criteria
+
+1. With the fix applied, when `WebviewWindowBuilder::build()` is forced to fail for the Full mode primary path, the safe-defaults fallback is attempted, and the user observes either (a) a working window from the fallback or (b) a clear panic from Tauri — never a silent zombie process.
+2. With the fix applied, when both the primary and fallback builds fail, `setup()` returns `Err`, which propagates through `tauri::Builder::build().expect(...)` and causes Tauri to panic with the configured error message.
+3. Unit tests for the safe-defaults configuration pass.
+4. `cargo build` (and `cargo test`, where applicable) inside `src-tauri/` succeed.
+5. PR body includes `Closes #69`.
+
+## Traceability
+
+| requirements-init item | Expanded requirements |
+| --- | --- |
+| FR-001 (propagate Err from setup) | FR-001, FR-012 |
+| FR-002 (retry with safe defaults) | FR-002, FR-003, FR-004, FR-010 |
+| FR-003 (fallback also fails → propagate) | FR-005 |
+| FR-004 (log original failure reason) | FR-010 |
+| FR-005 (log show failure) | FR-011 |
+| FR-006 (Peek→Full fallback unchanged) | FR-006, FR-030, FR-031 |
+| NFR-001 (only modify lib.rs lines 119–129, 246–248) | NFR-001, NFR-002 |
+| NFR-002 (do not touch lines 183–191) | NFR-003 |
+| NFR-003 (preserve .visible(false)) | NFR-010 |
+| NFR-004 (extractable, unit-testable helpers) | NFR-020, NFR-021 |
+
+## Open Questions
+
+None blocking.

--- a/.kiro/specs/fix-create-window-error/spec.json
+++ b/.kiro/specs/fix-create-window-error/spec.json
@@ -1,0 +1,22 @@
+{
+  "feature_name": "fix-create-window-error",
+  "created_at": "2026-05-27T11:05:00Z",
+  "updated_at": "2026-05-27T11:05:00Z",
+  "language": "ja",
+  "phase": "tasks",
+  "approvals": {
+    "requirements": {
+      "generated": true,
+      "approved": true
+    },
+    "design": {
+      "generated": true,
+      "approved": true
+    },
+    "tasks": {
+      "generated": true,
+      "approved": true
+    }
+  },
+  "ready_for_implementation": true
+}

--- a/.kiro/specs/fix-create-window-error/tasks.md
+++ b/.kiro/specs/fix-create-window-error/tasks.md
@@ -1,0 +1,150 @@
+# Implementation Tasks: fix-create-window-error
+
+## Document Info
+
+- Feature: fix-create-window-error
+- Total tasks: 5
+- Parallelizable: 0 (all tasks edit the same file: `src-tauri/src/lib.rs`)
+- Created: 2026-05-27
+- Related issue: kusa #69
+
+## Task Dependency Graph
+
+```
+T-001 (Full-mode fallback + show-error logging)
+   │
+   ▼
+T-002 (setup: propagate create_window Err)
+   │
+   ▼
+T-003 (in-file safe_default_full_size helper + tests module)
+   │
+   ▼
+T-004 (cargo test + cargo build verification)
+   │
+   ▼
+T-005 (commit + PR with `Closes #69`)
+```
+
+## Parallel Execution Groups
+
+None. All implementation tasks touch `src-tauri/src/lib.rs`. They are sequenced to keep diffs reviewable.
+
+## Tasks
+
+### T-001: Full-mode fallback + show-error logging
+
+- **Description**: In `src-tauri/src/lib.rs` `create_window`, replace the current Full-mode branch (lines 119–129) so that:
+  1. The primary `WebviewWindowBuilder::new(...).build()` result is captured in a `match`.
+  2. On `Ok(w)`, call `w.show()` and log any error via `eprintln!("Failed to show window: {}", e)` (no `.ok()` drop).
+  3. On `Err(e)`, log `eprintln!("Failed to create full window: {}, retrying with safe defaults", e)` and run a safe-defaults fallback `WebviewWindowBuilder::new(app, "main", WebviewUrl::default()).title("kusa").inner_size(FULL_SIZE.width, FULL_SIZE.height).decorations(true).visible(false).build()?`.
+  4. On fallback `Ok(w2)`, call `w2.show()` with the same logging treatment.
+  5. Do **not** modify `WindowModeState` and do **not** emit `window-mode` from this branch (matches existing behaviour).
+- **Files**: `src-tauri/src/lib.rs` (only the Full-mode branch around lines 119–129).
+- **Dependencies**: None.
+- **Acceptance Criteria**:
+  - [ ] Primary build success path retains `.min_inner_size(400.0, 300.0)` and `.visible(false)`.
+  - [ ] `window.show()` error is logged in **both** success paths (primary and fallback), not silently dropped.
+  - [ ] Fallback builder uses `title("kusa")`, `inner_size(FULL_SIZE.width, FULL_SIZE.height)`, `decorations(true)`, `visible(false)`, and no `min_inner_size`.
+  - [ ] Fallback `build()` `Err` is propagated via `?`.
+  - [ ] `cargo build` inside `src-tauri/` succeeds after the change.
+- **Tests**: deferred to T-003 (in-file helper unit tests).
+- **Effort**: Small (~30 min).
+
+### T-002: setup — propagate `create_window` Err
+
+- **Description**: In `src-tauri/src/lib.rs` `setup` closure (around lines 246–248), change `if let Err(e) = create_window(app, &peek_config) { eprintln!("Fatal: failed to create window: {}", e); }` to additionally `return Err(e);` after the `eprintln!`. This causes Tauri to panic on fatal window-creation failure instead of silently returning `Ok(())`.
+- **Files**: `src-tauri/src/lib.rs` (only the 3-line block around lines 246–248).
+- **Dependencies**: T-001 (sequenced for ordering; conceptually independent).
+- **Acceptance Criteria**:
+  - [ ] `eprintln!("Fatal: failed to create window: {}", e)` is preserved.
+  - [ ] An explicit `return Err(e);` follows the `eprintln!`.
+  - [ ] `cargo build` inside `src-tauri/` still succeeds (`setup` closure return type is `Result<_, Box<dyn std::error::Error>>` which is compatible).
+  - [ ] No lines outside 246–248 are modified by this task.
+- **Tests**: covered by manual/runtime behaviour; unit-testable assertion is the type-checked `?`/`return Err` shape.
+- **Effort**: Small (~10 min).
+
+### T-003: in-file `safe_default_full_size` helper + `#[cfg(test)] mod tests`
+
+- **Description**: At the bottom of `src-tauri/src/lib.rs`, add a module-private `const fn safe_default_full_size() -> window_presets::WindowSize { window_presets::FULL_SIZE }` (or use the already-imported `FULL_SIZE` symbol). Then add a `#[cfg(test)] mod tests { use super::*; ... }` block containing two tests:
+  1. `safe_default_full_size_matches_full_size` — asserts width/height equal `FULL_SIZE`.
+  2. `safe_default_full_size_is_positive` — asserts `width > 0.0 && height > 0.0`.
+  Adjust T-001's fallback to call `safe_default_full_size()` instead of inlining `FULL_SIZE.width/height` so the helper is in the live code path (avoids dead-code warnings under non-test builds).
+- **Files**: `src-tauri/src/lib.rs` (new helper near the existing top-level fns, and a new `#[cfg(test)] mod tests` at the bottom; also update T-001's fallback callsite).
+- **Dependencies**: T-001.
+- **Acceptance Criteria**:
+  - [ ] Helper is `const fn`, module-private (no `pub`).
+  - [ ] `safe_default_full_size()` is called from the Full-mode fallback path so it is exercised in non-test builds.
+  - [ ] `cargo test` inside `src-tauri/` runs and the two new tests pass.
+  - [ ] No new `clippy::dead_code` warnings.
+- **Tests**: the two unit tests added in this task.
+- **Effort**: Small (~20 min).
+
+### T-004: verification (`cargo build` + `cargo test`)
+
+- **Description**: From `src-tauri/`, run `cargo build` and `cargo test`. Confirm both succeed. If the workspace has additional checks (e.g., `cargo clippy`), run them too and address any new warnings introduced by this change.
+- **Files**: none (verification only).
+- **Dependencies**: T-001, T-002, T-003.
+- **Acceptance Criteria**:
+  - [ ] `cargo build` succeeds with no new errors.
+  - [ ] `cargo test` succeeds and includes the two new tests.
+  - [ ] `cargo clippy -- -D warnings` succeeds (if the project uses it as gate).
+- **Tests**: this is the integration check.
+- **Effort**: Small (~10 min).
+
+### T-005: commit, push, PR (Closes #69)
+
+- **Description**: Commit changes on the current worktree branch with Conventional Commits (`fix:` prefix), push to origin, then create a PR with `Closes #69` in the body. After PR creation, post `@coderabbitai review` and wait for review; address any actionable feedback by amending follow-up commits (NOT `--amend`), pushing again. Auto-merge handled by konbini `solo-full-auto` preset.
+- **Files**: none (git/gh operations).
+- **Dependencies**: T-004.
+- **Acceptance Criteria**:
+  - [ ] Commit message follows `fix: ...` Conventional Commits style.
+  - [ ] `git commit --no-verify` is NOT used.
+  - [ ] PR body contains the string `Closes #69`.
+  - [ ] PR is created and pushed to origin.
+  - [ ] CodeRabbit review is requested.
+- **Tests**: CI must pass before merge (handled by konbini auto-merge gate).
+- **Effort**: Small (~15 min, plus review wait time).
+
+## File Conflict Matrix
+
+| Task | Files | Conflicts With |
+| --- | --- | --- |
+| T-001 | `src-tauri/src/lib.rs` (lines 119–129 region) | T-002, T-003 |
+| T-002 | `src-tauri/src/lib.rs` (lines 246–248 region) | T-001, T-003 |
+| T-003 | `src-tauri/src/lib.rs` (bottom of file + T-001 callsite) | T-001, T-002 |
+| T-004 | none (verification) | None |
+| T-005 | none (git/gh) | None |
+
+All implementation tasks touch the same file but in distinct regions; sequential ordering avoids merge churn within the worktree.
+
+## Requirements Traceability
+
+| Requirement | Tasks |
+| --- | --- |
+| FR-001 | T-002 |
+| FR-002 | T-001 |
+| FR-003 | T-001 |
+| FR-004 | T-001 |
+| FR-005 | T-001 |
+| FR-006 | (verified by inspection in T-001; Peek branch untouched) |
+| FR-010 | T-001 |
+| FR-011 | T-001 |
+| FR-012 | T-002 |
+| FR-020 | T-001 |
+| FR-021 | T-001 |
+| FR-030 | T-001 (verification — Peek primary path unchanged) |
+| FR-031 | T-001 (verification — existing `build()?` preserved) |
+| NFR-001 | T-001, T-002, T-003 |
+| NFR-002 | T-001, T-002 |
+| NFR-003 | T-001, T-002 (lines 183–191 untouched by all tasks) |
+| NFR-010 | T-001 |
+| NFR-011 | T-001 |
+| NFR-020 | T-003 |
+| NFR-021 | T-003 |
+| NFR-030 | T-005 |
+| NFR-031 | T-005 |
+
+## Coordination notes (vs sibling issue #70)
+
+Issue #70 modifies `src-tauri/src/lib.rs` lines 183–191 and adds new commands in `commands.rs`. Our line ranges (119–129, 246–248, bottom of file) do not overlap. If a rebase conflict appears, preserve both sets of changes.

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -6,7 +6,15 @@ use std::path::PathBuf;
 use std::sync::Mutex;
 use tauri::{Emitter, WebviewWindowBuilder, WebviewUrl, Manager, RunEvent};
 use tauri_plugin_cli::CliExt;
-use window_presets::{PeekConfig, FULL_SIZE, PEEK_MIN_SIZE, resolve_preset};
+use window_presets::{PeekConfig, WindowSize, FULL_SIZE, PEEK_MIN_SIZE, resolve_preset};
+
+/// Size used for the Full-mode safe-defaults fallback when the primary
+/// `WebviewWindowBuilder` fails (e.g. due to a corrupted window-state file
+/// restored by `tauri_plugin_window_state`). Kept as a tiny helper so it can
+/// be unit-tested without launching a Tauri runtime.
+const fn safe_default_full_size() -> WindowSize {
+    FULL_SIZE
+}
 
 /// Stores the window mode so the frontend can query it via a Tauri command.
 #[derive(Debug, Default)]
@@ -117,15 +125,36 @@ fn create_window(app: &tauri::App, peek_config: &PeekConfig) -> Result<(), Box<d
             }
         }
     } else {
-        // Full mode: standard window with decorations
-        let window = WebviewWindowBuilder::new(app, "main", WebviewUrl::default())
+        // Full mode: standard window with decorations.
+        // On primary build failure, retry with a safe-defaults builder that
+        // does not depend on any plugin-restored state (e.g. a corrupted
+        // window-state file from `tauri_plugin_window_state`).
+        let result = WebviewWindowBuilder::new(app, "main", WebviewUrl::default())
             .title("kusa")
             .inner_size(peek_config.size.width, peek_config.size.height)
             .min_inner_size(400.0, 300.0)
             .decorations(true)
             .visible(false)
-            .build()?;
-        window.show().ok();
+            .build();
+        let window = match result {
+            Ok(w) => w,
+            Err(e) => {
+                eprintln!(
+                    "Failed to create full window: {}, retrying with safe defaults",
+                    e
+                );
+                let safe = safe_default_full_size();
+                WebviewWindowBuilder::new(app, "main", WebviewUrl::default())
+                    .title("kusa")
+                    .inner_size(safe.width, safe.height)
+                    .decorations(true)
+                    .visible(false)
+                    .build()?
+            }
+        };
+        if let Err(e) = window.show() {
+            eprintln!("Failed to show window: {}", e);
+        }
     }
 
     Ok(())
@@ -242,9 +271,13 @@ pub fn run() {
                 *mode = mode_str.to_string();
             }
 
-            // Create the window
+            // Create the window.
+            // If this fails (including the safe-defaults fallback for full
+            // mode), propagate the error so Tauri panics at startup rather
+            // than leaving a windowless zombie process.
             if let Err(e) = create_window(app, &peek_config) {
                 eprintln!("Fatal: failed to create window: {}", e);
+                return Err(e);
             }
 
             // Resolve file path to absolute, trying multiple base directories
@@ -331,4 +364,23 @@ pub fn run() {
                 }
             }
         });
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn safe_default_full_size_matches_full_size() {
+        let s = safe_default_full_size();
+        assert_eq!(s.width, FULL_SIZE.width);
+        assert_eq!(s.height, FULL_SIZE.height);
+    }
+
+    #[test]
+    fn safe_default_full_size_is_positive() {
+        let s = safe_default_full_size();
+        assert!(s.width > 0.0, "fallback width must be positive");
+        assert!(s.height > 0.0, "fallback height must be positive");
+    }
 }


### PR DESCRIPTION
## Summary

- Make `setup()` return `Err` when `create_window` fails so Tauri panics visibly instead of leaving a windowless zombie process in the Dock.
- Add a safe-defaults fallback to the Full-mode `WebviewWindowBuilder` path so a corrupted plugin-restored window state (or other transient build failure) does not stop kusa from opening a window.
- Log `window.show()` errors via `eprintln!` rather than silently dropping them with `.ok()`.

Closes #69

## Changes

`src-tauri/src/lib.rs` only:

1. **Full mode branch (lines 119-129 region)** — wrap primary `WebviewWindowBuilder::build()` in a `match`. On `Err`, log and retry with safe-defaults config: `title(\"kusa\")`, `inner_size(FULL_SIZE.*)`, `decorations(true)`, `visible(false)`, no `min_inner_size`. If the fallback also fails, propagate via `?`.
2. **`setup` closure (lines 246-248 region)** — after `eprintln!(\"Fatal: ...\")`, add `return Err(e);` so the error reaches `tauri::Builder::build(...).expect(\"error while building kusa\")` and Tauri panics.
3. **New helper** — module-private `const fn safe_default_full_size() -> WindowSize { FULL_SIZE }`, plus a `#[cfg(test)] mod tests` block with two unit tests (`safe_default_full_size_matches_full_size`, `safe_default_full_size_is_positive`).

## Constraints respected

- Only `src-tauri/src/lib.rs` is modified.
- Lines 183-191 (single-instance plugin, owned by sibling issue #70) are untouched.
- `.visible(false)` is preserved in both primary and fallback builders.
- No `git commit --no-verify`.
- Optional `--reset-window` flag (issue #69 item 3) is intentionally deferred to a future issue per the task description.

## Test plan

- [x] `cargo build` (src-tauri) — succeeds, no new warnings
- [x] `cargo test` (src-tauri) — 41 tests pass, including the two new ones
- [ ] CodeRabbit review acknowledged
- [ ] CI green
- [ ] Auto-merge per `solo-full-auto` preset