### PR TITLE
chore: update Cargo.lock for 0.3.10

### DIFF
--- a/src-tauri/Cargo.lock
+++ b/src-tauri/Cargo.lock
@@ -2191,7 +2191,7 @@ dependencies = [
 
 [[package]]
 name = "kusa"
-version = "0.3.9"
+version = "0.3.10"
 dependencies = [
  "base64 0.22.1",
  "dirs",


### PR DESCRIPTION
Cargo.lock bump after `bun run tauri build` on v0.3.10.